### PR TITLE
Add recognized contributors documents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
@@ -1,0 +1,22 @@
+I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).
+
+**Name:** NAME
+**GitHub Username:** USERNAME
+**Projects/SIGs:**
+<!-- 
+List projects or SIGs this person is affiliated with.
+Note that an individual is not required to be affiliated
+with a project before becoming an RC
+-->
+- PROJECT OR SIG NAME
+
+## Nomination
+In 2-5 sentences, describe this person's activity within BytecodeAlliance. Examples include SIG activity, project contributions.
+
+## Optional: Endorsements
+<!--
+List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
+-->
+- NAME (GH USERNAME)
+
+- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

--- a/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
@@ -4,7 +4,7 @@ I am nominating or self-nominating a [Recognized Contributor](https://github.com
 **GitHub Username:** USERNAME
 **Projects/SIGs:**
 <!-- 
-List projects or SIGs this person is affiliated with.
+List projects or SIGs this person is affiliated with, if any.
 Note that an individual is not required to be affiliated
 with a project before becoming an RC
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/recognized-contributor.md
@@ -11,7 +11,7 @@ with a project before becoming an RC
 - PROJECT OR SIG NAME
 
 ## Nomination
-In 2-5 sentences, describe this person's activity within BytecodeAlliance. Examples include SIG activity, project contributions.
+In 2-5 sentences, describe this person's activity within the Bytecode Alliance. Examples include SIG activity, project contributions, and supporting Bytecode Alliance-wide initiatives.
 
 ## Optional: Endorsements
 <!--

--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -1,0 +1,23 @@
+# Recognized Contributors
+
+The following is a list of [Recognized Contributors](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors), ordered by last name. Recognized Contributors carry certain roles and responsibilities in the Bytecode Alliance, including (but not limited to) voting in various Bytecode Alliance elections.
+
+To nominate a new Recognized Contributor, make a pull request adding the candidate to this list, and then choose and complete the `recognized-contributor` pull request template. _Self-nominations are allowed._
+
+Format of entries: `Surname, First name (GitHub Username)`. When it is traditional to put surname first, the comma is omitted.
+
+## A-E
+
+Butcher, Matt (technosophos)
+
+## F-J
+
+## K-O
+
+## P-T
+
+Schneidereit, Till (tschneidereit)
+
+## U-Z
+
+Wang Xin (xwang98)


### PR DESCRIPTION
This PR does the following:

- Adds an initial `recognized-contributors.md` list of RCs
- Seeds that list with the existing proto-TSC
- Adds a GitHub template for opening new pull requests to add new RCs

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>