### PR TITLE
Recognized Contributors for wasi-nn and wasi-parallel

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -8,15 +8,23 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 
 ## A-E
 
+Birch Jr, Johnnie L (@jlb6740)  
+Brown, Andrew (@abrown)  
 Butcher, Matt (technosophos)
 
 ## F-J
+
+Galli, Enrico (@egalli)  
+Jones, Brian J (@brianjjones)  
 
 ## K-O
 
 ## P-T
 
-Schneidereit, Till (tschneidereit)
+Penzin, Petr (@penzn)  
+Schneidereit, Till (tschneidereit)  
+Schoettler, Steve (@stevelr)  
+Sun, Mingqiu (@mingqiusun)  
 
 ## U-Z
 

--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -30,7 +30,6 @@ Noorali, Michelle (@michelleN)
 ## P-T
 
 Penzin, Petr (@penzn)  
-Schneidereit, Till (tschneidereit)  
 Schoettler, Steve (@stevelr)  
 Thomas, Taylor (@thomastaylor312)
 Schneidereit, Till (@tschneidereit)

--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -10,7 +10,6 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 
 Birch Jr, Johnnie L (@jlb6740)  
 Brown, Andrew (@abrown)  
-Butcher, Matt (technosophos)
 
 ## F-J
 


### PR DESCRIPTION
I am nominating the participants of WASI-NN and WASI-Parallel to become Recognized Contributors. I am nominating this group because I have observed each of these people participate in the WASI-NN and WASI-Parallel projects.

https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors

Can the following people 👍 if you accept this nomination to be a Recognized Contributor, or 👎 to decline the nomination?

Birch Jr, Johnnie L (@jlb6740)
Brown, Andrew (@abrown)
Galli, Enrico (@egalli)
Jones, Brian J (@brianjjones)
Penzin, Petr (@penzn)
Schoettler, Steve (@stevelr)
Sun, Mingqiu (@mingqiusun)
Matei, Radu (@radu-matei)

If we don't hear from you by March 31, I'll remove you from the PR and we can add you later if you so desire.

Recognized Contributors can vote in certain Bytecode Alliance elections. To be an RC, you must be an active contributor to one of the Bytecode Alliance projects. You can read more here: https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors