### PR TITLE
Add Cranelift contributors to recognized contributors list

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -9,19 +9,31 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 ## A-E
 
 Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))  
+bjorn3 ([@bjorn3](https://github.com/bjorn3))  
+Bouvier, Benjamin ([@bnjbvr](https://github.com/bnjbvr))  
 Brown, Andrew ([@abrown](https://github.com/abrown))  
 Butcher, Matt ([@technosophos](https://github.com/technosophos))  
+Cabrera, Javier ([@Jacarte](https://github.com/Jacarte))  
+Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))  
 
 ## F-J
 
+Fallin, Chris ([@cfallin](https://github.com/cfallin))  
+Fitzgerald, Nick ([@fitzgen](https://github.com/fitzgen))  
+Foltzer, Adam ([@acfoltzer](https://github.com/acfoltzer))  
 Galli, Enrico ([@egalli](https://github.com/egalli))  
-Jones, Brian J ([@brianjjones](https://github.com/brianjjones))  
+Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))  
 Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))  
 Hayes, Bailey ([@ricochet](https://github.com/ricochet))  
+Heaton, Damian ([@dheaton](https://github.com/dheaton-arm))  
+Hickey, Pat ([@pchickey](https://github.com/pchickey))  
 Huene, Peter ([@peterhuene](https://github.com/peterhuene))  
+iximeow ([@iximeow](https://github.com/iximeow))  
+Jones, Brian J ([@brianjjones](https://github.com/brianjjones))  
 
 ## K-O
 
+Kirilov, Anton ([@akirilov](https://github.com/akirilov-arm))  
 Kulakowski, George ([@kulakowski](https://github.com/kulakowski-wasm))  
 Matei, Radu ([@radu](https://github.com/radu-matei))  
 McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))  
@@ -29,16 +41,18 @@ Noorali, Michelle ([@michelleN](https://github.com/michelleN))
 
 ## P-T
 
+Parker, Sam ([@sparker](https://github.com/sparker-arm))  
 Penzin, Petr ([@penzn](https://github.com/penzn))  
-Schoettler, Steve ([@stevelr](https://github.com/stevelr))  
-Thomas, Taylor ([@thomastaylor312](https://github.com/thomastaylor312))  
 Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))  
+Schoettler, Steve ([@stevelr](https://github.com/stevelr))  
 Squillace, Ralph ([@squillace](https://github.com/squillace))  
 Sun, Mingqiu ([@mingqiusun](https://github.com/mingqiusun))  
 Sverre, Carl ([@carlsverre](https://github.com/carlsverre))  
+Thomas, Taylor ([@thomastaylor312](https://github.com/thomastaylor312))  
 
 ## U-Z
 
 Volosatovs, Roman ([@rvolosatovs](https://github.com/rvolosatovs))  
 Wagner, Luke ([@lukewagner](https://github.com/lukewagner))  
 Wang Xin ([@xwang98](https://github.com/xwang98))  
+Weigand, Ulrich ([@uweigand](https://github.com/uweigand))  

--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -25,7 +25,7 @@ Galli, Enrico ([@egalli](https://github.com/egalli))
 Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))  
 Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))  
 Hayes, Bailey ([@ricochet](https://github.com/ricochet))  
-Heaton, Damian ([@dheaton](https://github.com/dheaton-arm))  
+Heaton, Damian ([@dheaton-arm](https://github.com/dheaton-arm))  
 Hickey, Pat ([@pchickey](https://github.com/pchickey))  
 Huene, Peter ([@peterhuene](https://github.com/peterhuene))  
 iximeow ([@iximeow](https://github.com/iximeow))  
@@ -33,7 +33,7 @@ Jones, Brian J ([@brianjjones](https://github.com/brianjjones))
 
 ## K-O
 
-Kirilov, Anton ([@akirilov](https://github.com/akirilov-arm))  
+Kirilov, Anton ([@akirilov-arm](https://github.com/akirilov-arm))  
 Kulakowski, George ([@kulakowski](https://github.com/kulakowski-wasm))  
 Matei, Radu ([@radu](https://github.com/radu-matei))  
 McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))  
@@ -41,7 +41,7 @@ Noorali, Michelle ([@michelleN](https://github.com/michelleN))
 
 ## P-T
 
-Parker, Sam ([@sparker](https://github.com/sparker-arm))  
+Parker, Sam ([@sparker-arm](https://github.com/sparker-arm))  
 Penzin, Petr ([@penzn](https://github.com/penzn))  
 Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))  
 Schoettler, Steve ([@stevelr](https://github.com/stevelr))  


### PR DESCRIPTION
I am nominating a set of contributors to Cranelift to become [Recognized Contributors](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors). I am nominating this group because I have observed each of these people have a strong history of contributions to Cranelift and are likely to continue contributing going forward.

Can the following people 👍 if you accept this nomination to be a Recognized Contributor, or 👎 to decline the nomination?

bjorn3 (@bjorn3)
Bouvier, Benjamin (@bnjbvr)
Cabrera, Javier (@Jacarte)
Crichton, Alex (@alexcrichton)
Fallin, Chris (@cfallin)
Fitzgerald, Nick (@fitzgen)
Foltzer, Adam (@acfoltzer)
Gohman, Dan (@sunfishcode)
Heaton, Damian (@dheaton-arm)
Hickey, Pat (@pchickey)
iximeow (@iximeow)
Kirilov, Anton (@akirilov-arm)
Parker, Sam (@sparker-arm)
Weigand, Ulrich (@uweigand)

If we don't hear from you by April 20 I'll remove you from the PR and we can add you later if you so desire. (Note that I have pre-cleared the nomination with some folks on the list, and will merge once everyone else has given a thumbs-up, and we have consensus on the TSC to accept these nominations.)

Recognized Contributors can vote in certain Bytecode Alliance elections. To be an RC, you must be an active contributor to one of the Bytecode Alliance projects. You can read more here: https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors