### PR TITLE
Add verification contributors to recognized contributors list

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -32,6 +32,7 @@ Holley, Bobby ([@bholley](https://github.com/bholley))
 Hoyer, Harald ([@haraldh](https://github.com/haraldh))  
 Huene, Peter ([@peterhuene](https://github.com/peterhuene))  
 iximeow ([@iximeow](https://github.com/iximeow))  
+Johnson, Evan ([@enjhnsn2](https://github.com/enjhnsn2))  
 Jones, Brian J ([@brianjjones](https://github.com/brianjjones))  
 
 ## K-O
@@ -41,6 +42,7 @@ Kulakowski, George ([@kulakowski](https://github.com/kulakowski-wasm))
 martin, katelyn ([@cratelyn](https://github.com/cratelyn))  
 Matei, Radu ([@radu](https://github.com/radu-matei))  
 McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))  
+Narayan, Shravan ([@shravanrn](https://github.com/shravanrn))  
 Noorali, Michelle ([@michelleN](https://github.com/michelleN))  
 
 ## P-T
@@ -50,6 +52,7 @@ Penzin, Petr ([@penzn](https://github.com/penzn))
 Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))  
 Schoettler, Steve ([@stevelr](https://github.com/stevelr))  
 Squillace, Ralph ([@squillace](https://github.com/squillace))  
+Stefan, Deian ([@deian](https://github.com/deian))  
 Sun, Mingqiu ([@mingqiusun](https://github.com/mingqiusun))  
 Sverre, Carl ([@carlsverre](https://github.com/carlsverre))  
 Thomas, Taylor ([@thomastaylor312](https://github.com/thomastaylor312))  


### PR DESCRIPTION
I am nominating a set of contributors to the Bytecode Alliance's formal verification efforts to become Recognized Contributors. I am nominating this group because I have observed each of these people have a strong history of contributions to the Bytecode Alliance's formal verification efforts and are likely to continue contributing going forward. (Note that this list is so short because many folks are also contributors to other efforts that were covered by earlier PRs.)

Can the following people 👍 if you accept this nomination to be a Recognized Contributor, or 👎 to decline the nomination?

Johnson, Evan (@enjhnsn2)
Narayan, Shravan (@shravanrn)
Stefan, Deian (@deian)

If we don't hear from you by April 20 I'll remove you from the PR and we can add you later if you so desire.

Recognized Contributors can vote in certain Bytecode Alliance elections. To be an RC, you must be an active contributor to one of the Bytecode Alliance projects. You can read more here: https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors