### PR TITLE
Publishing Bytecode Alliance Whistleblower Policy

### DIFF
--- a/WHISTLEBLOWER_POLICY.md
+++ b/WHISTLEBLOWER_POLICY.md
@@ -1,0 +1,41 @@
+# BYTECODE ALLIANCE FOUNDATION WHISTLEBLOWER POLICY
+
+The Bytecode Alliance Foundation (the “Organization”) requires all representatives of the Organization, including directors, officers, employees, contractors, and volunteers (“representatives”) to observe high standards of business and personal ethics in the conduct of their duties and responsibilities. As representatives of the Organization, we must practice honesty and integrity in fulfilling our responsibilities and comply with all applicable laws and regulations.
+
+## Reporting Responsibility
+This Whistleblower Policy is intended to encourage and enable representatives of the Organization to raise serious concerns internally so that the Organization can address and correct inappropriate conduct and actions. It is the responsibility of all representatives of the Organization to report concerns about violations of the Organization’s ethical duties or suspected violations of law or regulations that govern the Organization’s operations.
+
+## No Retaliation
+It is contrary to the values of the Organization for anyone to retaliate against anyone who in good faith reports an ethics violation, or a suspected violation of law, such as a complaint of discrimination, or suspected fraud, or suspected violation of any regulation governing the operations of the Organization. A representative of the Organization who retaliates against someone who has reported a violation in good faith is subject to discipline up to and including termination of employment.
+
+## Compliance Officer
+The Organization’s Executive Director serves as Compliance Officer and is responsible for ensuring that all complaints about unethical or illegal conduct are investigated and resolved. The Compliance Officer will advise the Board of Directors of all complaints and their resolution and will report at least annually to the Board on compliance activity relating to accounting or alleged financial improprieties.
+
+## Reporting Procedure
+The Organization has an open door policy and suggests that representatives share their questions, concerns, suggestions or complaints with any Director on the Organization Board. Alternatively, or in addition to speaking with any Director, or if you are not satisfied with a Director’s response, you are encouraged to speak with the Executive Director. 
+
+Concerns may also be submitted in writing as email to complaint@bytecodealliance.org. All such reports will be reviewed by Foundation legal counsel before being routed to the Compliance Officer or Board of Directors as appropriate in accordance with this policy
+
+Directors and the Executive Director (“Covered Officials”) are required to report complaints or concerns about suspected ethical and legal violations in writing to the Organization’s Compliance Officer, who has the responsibility to investigate all reported complaints. Directors receiving complaints about the Executive Director may, given the Executive Director’s role as Compliance Officer, convene a session of the Board of Directors without the Executive Director present to review and address the matter.
+
+## Accounting and Auditing Matters
+The Compliance Officer must immediately notify the Board of Directors of any concerns or complaint regarding corporate accounting practices, internal controls or auditing and work with the committee until the matter is resolved.
+
+## Acting in Good Faith
+Anyone filing a written complaint concerning a violation or suspected violation must be acting in good faith and have reasonable grounds for believing the information disclosed indicates a violation. Any allegations that prove not to be substantiated and which prove to have been made maliciously or knowingly to be false will be viewed as a serious disciplinary offense.
+
+## Confidentiality
+Violations or suspected violations may be submitted on a confidential basis by the complainant. Reports of violations or suspected violations will be kept confidential to the extent possible, consistent with the need to conduct an adequate investigation.
+## Annual Acknowledgement Process
+On an annual basis, each member of the Board of Directors as well as the Executive Director, shall be provided with a copy of this policy, and shall complete and sign the acknowledgement below.
+
+## Handling of Reported Violations
+The Organization’s Compliance Officer will notify the person who submitted a complaint and acknowledge receipt of the reported violation or suspected violation. All reports will be promptly investigated and appropriate corrective action will be taken if warranted by the investigation.
+
+Compliance Officer:
+David Bryant
+Consulting Executive Director, Bytecode Alliance
+david@bytecodealliance.org
+
+
+Policy approved by the Board of Directors on September 22, 2022.


### PR DESCRIPTION
The Bytecode Alliance Foundation Board approved an official Whistleblower policy on September 22, 2022.   Adding that policy as a separate document in the governance repo to make it public and easily referred to.