### PR TITLE
Correct a URL to point to the official source.

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -1,6 +1,6 @@
 # Recognized Contributors
 
-The following is a list of [Recognized Contributors](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors), ordered by last name. Recognized Contributors carry certain roles and responsibilities in the Bytecode Alliance, including (but not limited to) voting in various Bytecode Alliance elections.
+The following is a list of [Recognized Contributors](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors), ordered by last name. Recognized Contributors carry certain roles and responsibilities in the Bytecode Alliance, including (but not limited to) voting in various Bytecode Alliance elections.
 
 To nominate a new Recognized Contributor, make a pull request adding the candidate to this list, and then choose and complete the `recognized-contributor` pull request template. _Self-nominations are allowed._
 


### PR DESCRIPTION
Correct a URL to the charter.md documentat to point to the copy in the official bytecodealliance repository.