### PR TITLE
Add Trevor Elliott as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -18,6 +18,7 @@ Cabrera, Saúl ([@saulecabrera](https://github.com/saulecabrera))
 Clark, Lin ([@linclark](https://github.com/linclark))  
 Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))  
 Delendik, Yury ([@yurydelendik](https://github.com/yurydelendik))  
+Elliott, Trevor ([@elliottt](https://github.com/elliottt))
 Ene, Alexandru ([@AlexEne](https://github.com/AlexEne))  
 
 ## F-J


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Trevor Elliott
**GitHub Username:** @elliottt
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- Wasmtime
- Cranelift

## Nomination
Extensive work on Cranelift and Wasmtime in the last few months: https://github.com/bytecodealliance/wasmtime/commits?author=elliottt

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- @fitzgen

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)