### PR TITLE
Add Afonso Bordado as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -10,6 +10,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 
 Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))  
 bjorn3 ([@bjorn3](https://github.com/bjorn3))  
+Bordado, Afonso ([@afonso360](https://github.com/afonso360))  
 Bouvier, Benjamin ([@bnjbvr](https://github.com/bnjbvr))  
 Brown, Andrew ([@abrown](https://github.com/abrown))  
 Butcher, Matt ([@technosophos](https://github.com/technosophos))  


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Afonso Bordado
**GitHub Username:** @afonso360
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- Cranelift

## Nomination
Extensive work on Cranelift, its interpreter, and fuzzing infrastructure over the last year: https://github.com/bytecodealliance/wasmtime/commits?author=afonso360

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- @fitzgen

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)