### PR TITLE
Add Liang Tianlong as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -48,6 +48,7 @@ Jones, Brian J ([@brianjjones](https://github.com/brianjjones))
 
 Kirilov, Anton ([@akirilov-arm](https://github.com/akirilov-arm))  
 Kulakowski, George ([@kulakowski](https://github.com/kulakowski-wasm))  
+Liang Tianlong[@TianlongLiang](https://github.com/TianlongLiang)  
 martin, katelyn ([@cratelyn](https://github.com/cratelyn))  
 Matei, Radu ([@radu](https://github.com/radu-matei))  
 McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))  


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Liang Tianlong
**GitHub Username:** @TianlongLiang
**Projects/SIGs:** 
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- WAMR

## Nomination
Extensive work on WAMR, its debugger support, document and infrastructure over the last year: 
https://github.com/bytecodealliance/wasm-micro-runtime/commits?author=TianlongLiang

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- @xwang98 

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)