### PR TITLE
add myself to RC list

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -18,6 +18,7 @@ Cabrera, Saúl ([@saulecabrera](https://github.com/saulecabrera))
 Clark, Lin ([@linclark](https://github.com/linclark))  
 Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))  
 Delendik, Yury ([@yurydelendik](https://github.com/yurydelendik))  
+Dice, Joel ([@dicej](https://github.com/dicej))  
 Ene, Alexandru ([@AlexEne](https://github.com/AlexEne))  
 
 ## F-J


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Joel Dice
**GitHub Username:** dicej
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- N/A

## Nomination
I've contributed to the Wasmtime component model implementation, the `wit-bindgen` Java guest binding generator, and, most recently, the WASI Preview 2 host implementation and guest module adapter.  

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Radu Matei (@radu-matei)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

Signed-off-by: Joel Dice <joel.dice@fermyon.com>