### PR TITLE
Propose SIG-dynamic-languages

### DIFF
--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -9,7 +9,7 @@ The group will maintain lists of dynamic language guest projects, common foundat
 
 ## Supporting Members
 
-The following individuals support the creation of $SIG_NAME:
+The following individuals support the creation of SIG-dynamic-laguages
 
 * Bedford, Guy (Fastly)
 * Brown, Kyle (SingleStore)

--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -23,4 +23,5 @@ The following individuals support the creation of $SIG_NAME:
 * Prewitt, Calvin (JAF Labs)
 * Schneidereit, Till (Fermyon)
 * Vetere, Peter (SingleStore)
+* Wagner, Luke (Fastly)
 

--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -1,0 +1,26 @@
+# Proposal to Create SIG-dynamic-languages
+
+This document is a proposal to create SIG-dynamic-languages as a formal Special Interest Group (SIG) under the auspices of the TSC of the Bytecode Alliance, as specified in the TSC’s charter.
+
+The purpose of this group is to make it easier for dynamic programming languages with non-trivial runtimes and interpreters to be compiled to Wasm.
+The group will attempt to achieve this by bringing together different interpreted language guest projects, identifying common foundational issues faced by those projects, and coordinating work on common tooling and solutions.
+
+The group will maintain lists of dynamic language guest projects, common foundational issues, implementation patterns, and common tools. The group will not be responsible for identified projects or tools but will act as a place for people to discover and collaborate on them and raise feedback to the Bytecode Alliance and its TSC.
+
+## Supporting Members
+
+The following individuals support the creation of $SIG_NAME:
+
+* Brown, Kyle (SingleStore)
+* Cabrera, Saúl (Shopify)
+* Chiarlone, Dan (Microsoft)
+* Dice, Joel (Fermyon)
+* Huene, Peter (Fastly)
+* Sharp, Jamey (Fastly)
+* Jiaxiao, Zhou (Microsoft)
+* Smith, Kevin (SingleStore)
+* Macovei, Danny (JAF Labs)
+* Prewitt, Calvin (JAF Labs)
+* Schneidereit, Till (Fermyon)
+* Vetere, Peter (SingleStore)
+

--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -11,6 +11,7 @@ The group will maintain lists of dynamic language guest projects, common foundat
 
 The following individuals support the creation of $SIG_NAME:
 
+* Bedford, Guy (Fastly)
 * Brown, Kyle (SingleStore)
 * Cabrera, Saúl (Shopify)
 * Chiarlone, Dan (Microsoft)

--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -14,6 +14,7 @@ The following individuals support the creation of $SIG_NAME:
 * Bedford, Guy (Fastly)
 * Brown, Kyle (SingleStore)
 * Cabrera, Saúl (Shopify)
+* Cannon, Brett (Microsoft)
 * Chiarlone, Dan (Microsoft)
 * Dice, Joel (Fermyon)
 * Huene, Peter (Fastly)

--- a/SIGs/SIG-dynamic-languages/proposal.md
+++ b/SIGs/SIG-dynamic-languages/proposal.md
@@ -2,14 +2,23 @@
 
 This document is a proposal to create SIG-dynamic-languages as a formal Special Interest Group (SIG) under the auspices of the TSC of the Bytecode Alliance, as specified in the TSC’s charter.
 
-The purpose of this group is to make it easier for dynamic programming languages with non-trivial runtimes and interpreters to be compiled to Wasm.
-The group will attempt to achieve this by bringing together different interpreted language guest projects, identifying common foundational issues faced by those projects, and coordinating work on common tooling and solutions.
+The purpose of this group is to investigate how best to integrate Wasm and components into dynamic programming language ecosystems in a way that feels native to those ecosystems.
 
-The group will maintain lists of dynamic language guest projects, common foundational issues, implementation patterns, and common tools. The group will not be responsible for identified projects or tools but will act as a place for people to discover and collaborate on them and raise feedback to the Bytecode Alliance and its TSC.
+The group will do this by bringing together dynamic language stakeholders, identifying common issues faced by dynamic languages, and coordinating work on common tooling and solutions.
+
+Any work the group does which involves engine extensions and runtime interfaces must enter the appropriate standardization process (e.g. Wasm CG, WASI) and not ship in production until they are at the appropriate point in the standardization process and are sufficiently stable.
+
+## Deliverables
+
+1. The group will produce a guide to supporting Wasm in dynamic languages based on identified common foundational issues (e.g. bundling standard libraries, linking runtime binaries) and common implementation patterns which address them.
+
+1. The group will develop common tools (e.g. a file system virtualizer) for use in dynamic language guest projects. These tools must be designed so they can be integrated into different project's native language tooling (e.g. [wasm-tools](https://github.com/bytecodealliance/wasm-tools) being used in [jco](https://github.com/bytecodealliance/jco/tree/main)).
+
+1. The group may develop new dynamic language guest projects. These projects must be designed to be used in and match the idioms of the source language's native tooling (e.g. [cargo component](https://github.com/bytecodealliance/cargo-component) being integrated into Rust & `cargo`). These projects must not fork existing languages; any/all required extensions to the source language must be coordinated with the languages maintainers and have a clear path to being upstreamed.
 
 ## Supporting Members
 
-The following individuals support the creation of SIG-dynamic-laguages
+The following individuals support the creation of SIG-dynamic-languages
 
 * Bedford, Guy (Fastly)
 * Brown, Kyle (SingleStore)


### PR DESCRIPTION
This SIG aims to help bring together stakeholders interested in running dynamic languages in Wasm.

I have individually received permission from each listed supporting member to be included in this proposal.

[rendered](https://github.com/Kylebrown9/governance/blob/SIG-dynamic-languages/SIGs/SIG-dynamic-languages/proposal.md)