### PR TITLE
Add Jiaxiao Zhou to recognized contributors

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -45,6 +45,7 @@ Huang Wenyong ([@wenyongh](https://github.com/wenyongh))
 Huene, Peter ([@peterhuene](https://github.com/peterhuene))  
 Hunt, Ryan ([@eqrion](https://github.com/eqrion))  
 iximeow ([@iximeow](https://github.com/iximeow))  
+Zhou, Jiaxiao([@mossaka](https://github.com/mossaka))  
 Johnson, Evan ([@enjhnsn2](https://github.com/enjhnsn2))  
 Jones, Brian J ([@brianjjones](https://github.com/brianjjones))  
 


### PR DESCRIPTION
I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Jiaxiao Zhou
**GitHub Username:** mossaka
**Projects/SIGs:**
- Contributor of tinygo bindgen in wit-bindgen
- Lead of wasi-cloud-core world proposal and associated WASI proposals 

## Nomination
Zhou is involved in many Bytecode Alliance activities with a primary focus of creating a software platform for wasi-cloud world. Additionally, he has made contributions to wit-bindgen for tinygo bindings support and contributions to the overall component model effort within the Bytecode Alliance. 

## Optional: Endorsements
- Bailey Hayes @ricochet

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)