### PR TITLE
Propose Language-Specific Subgroups of SIG-dynamic-languages

### DIFF
--- a/SIGs/SIG-dynamic-languages/subgroups.md
+++ b/SIGs/SIG-dynamic-languages/subgroups.md
@@ -1,0 +1,25 @@
+# SIG-dynamic-languages Subgroups
+
+This document is a proposal to create subgroups in the dynamic languages SIG.
+All subgroups will be viewed as a part of SIG-dynamic-languages and adhere to all of its rules.
+
+For a subgroup to be formed, there must be two or more members supporting its creation who have agreed to become its organizing members.
+Organizing members are responsible for scheduling and running, meetings and upholding the Bytecode Alliance Code of Conduct.
+
+Only one kind of subgroup is proposed initially, but this may be extended by future proposals.
+
+Subgroups and their organizing members are listed in this document. Any proposed subgroups or changes to the organizing members of a subgroup must be submitted as a PR to the governance repository, placed on the agenda for a SIG-dynamic-languages at least a week before its next meeting, and accepted by a vote.
+
+## Language-Specific Subgroups
+
+A language-specific subgroup will be focused on a single programming language ecosystem and
+exist to further the Wasm support for that language.
+
+The language-specific subgroups are
+
+* Python - organized by
+  * Joel Dice (Fermyon)
+  * Kevin Smith (SingleStore)
+* JavaScript & TypeScript (JS/TS) - organized by
+  * Calvin Prewitt (JAF Labs)
+  * Saúl Cabrera (Shopify)


### PR DESCRIPTION
As discussed in Thursday's meeting and as a way to create a framework for language-specific meetings, which have already taken place in an ad-hoc fashion, this proposal defines a subgroup process for SIG-dynamic-languages and one initial kind of subgroup: language-specific subgroups.

[rendered](https://github.com/Kylebrown9/governance/blob/sig-dynamic-languages-subgroups/SIGs/SIG-dynamic-languages/subgroups.md)