### PR TITLE
 Add Calvin Prewitt to recognized contributors

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -65,6 +65,7 @@ Noorali, Michelle ([@michelleN](https://github.com/michelleN))
 
 Parker, Sam ([@sparker-arm](https://github.com/sparker-arm))  
 Penzin, Petr ([@penzn](https://github.com/penzn))  
+Prewitt, Calvin ([@calvinrp](https://github.com/calvinrp))
 Qin Xiaokang ([@qinxk-inter](https://github.com/qinxk-inter))  
 Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))  
 Schoettler, Steve ([@stevelr](https://github.com/stevelr))  


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Calvin Prewitt
**GitHub Username:** @calvinrp
**Projects/SIGs:**
- SIG-Registries
- SIG-Dynamic-Languages

## Nomination
Calvin is very involved in the Registry group where he is helping to refine the scope of the warg protocol, assisting in the planning for Preview 2 readiness, and working with stakeholders to build consensus. Calvin also uses his Browser and JavaScript background to participate in the JavaScript host, guest, and registry design discussions.

## Optional: Endorsements
- Kyle Brown (@Kylebrown9)
- Peter Huene (@peterhuene)

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)