### PR TITLE
June 2023 TCS Governance Update

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Code of Conduct Team
 
-The Organization’s Code of Conduct Team is responsible for ensuring that all Code of Conduct complaints are investigated and resolved. It consists of the members of the Technical Steering Commmittee along with the Executive Director acting as Compliance Officer.  The Compliance Officer, on behalf of the Code of Conduct Team, will advise the Board of all complaints and their resolution and will report at least annually to the Board on compliance activity relating to the organizational Code of Conduct.
+The Organization’s Code of Conduct Team is responsible for ensuring that all Code of Conduct complaints are investigated and resolved. It consists of the members of the Technical Steering Commmittee along with the Executive Director acting as Compliance Officer. The Compliance Officer, on behalf of the Code of Conduct Team, will advise the Board of all complaints and their resolution and will report at least annually to the Board on compliance activity relating to the organizational Code of Conduct.
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,9 +32,13 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
+## Code of Conduct Team
+
+The Organization’s Code of Conduct Team is responsible for ensuring that all Code of Conduct complaints are investigated and resolved. It consists of the members of the Technical Steering Commmittee along with the Executive Director acting as Compliance Officer.  The Compliance Officer, on behalf of the Code of Conduct Team, will advise the Board of all complaints and their resolution and will report at least annually to the Board on compliance activity relating to the organizational Code of Conduct.
+
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Bytecode Alliance CoC team at [report@bytecodealliance.org](mailto:report@bytecodealliance.org). The CoC team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The CoC team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Bytecode Alliance CoC Team at [report@bytecodealliance.org](mailto:report@bytecodealliance.org). The CoC Team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The CoC Team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the Bytecode Alliance's leadership.
 

--- a/TSC/charter.md
+++ b/TSC/charter.md
@@ -104,7 +104,7 @@ The way TSC members are determined differs by the type of representation:
 
 * Each Core Project appoints, by a process of its choosing, a delegate to represent the project to the TSC
 
-Projects and Recognized Contributors are empowered to determine/elect delegates of their choosing from  candidates in good standing with the Bytecode Alliance and community.  However, no person may be nominated to serve on the TSC if that person or their employer is currently subject to any U.S. sanctions administered by the Office of Foreign Assets Control of the U.S. Treasury Department (“OFAC”).
+Projects and Recognized Contributors are empowered to determine/elect delegates of their choosing from candidates in good standing with the Bytecode Alliance and community. However, no person may be nominated to serve on the TSC if that person or their employer is currently subject to any U.S. sanctions administered by the Office of Foreign Assets Control of the U.S. Treasury Department (“OFAC”).
 
 The TSC operates on a two-year term cycle. An individual may be reelected or renominated to serve multiple terms.
 

--- a/TSC/charter.md
+++ b/TSC/charter.md
@@ -104,7 +104,7 @@ The way TSC members are determined differs by the type of representation:
 
 * Each Core Project appoints, by a process of its choosing, a delegate to represent the project to the TSC
 
-There are no required entry qualifications for someone to be a TSC delegate—projects and Recognized Contributors are free to determine/elect delegates of their choosing without constraints beyond being in good standing with the BA and community.
+Projects and Recognized Contributors are empowered to determine/elect delegates of their choosing from  candidates in good standing with the Bytecode Alliance and community.  However, no person may be nominated to serve on the TSC if that person or their employer is currently subject to any U.S. sanctions administered by the Office of Foreign Assets Control of the U.S. Treasury Department (“OFAC”).
 
 The TSC operates on a two-year term cycle. An individual may be reelected or renominated to serve multiple terms.
 
@@ -206,7 +206,7 @@ The Board of Directors will create resources (such as mailing lists and reposito
 
 Interest Group decisions should be made based upon consensus; if someone has strong objections, they should be heard and considered before being overridden. If a decision cannot be made by consensus, a simple majority vote of participating Bytecode Alliance members will decide the matter.
 
-The IG Chair(s) are responsible for arranging meetings, distributing agendas and minutes, and recording decisions. All IG business is to be conducted in public. The existence and charter of an interest group are to be made public, but the interest group may decide for itself whether its ongoing activity is made public.
+The IG Chair(s) are responsible for arranging meetings, distributing agendas and minutes, and recording decisions. All IG business is to be conducted in public.
 
 Interest Groups must operate in a manner that ensures ongoing alignment with the mission and operating principles of the Bytecode Alliance. Disagreement on whether specific aspects of the IG’s operations or outputs adhere to this requirement can be escalated to the TSC, which will provide an evaluation and, where it deems it necessary, recommend or request specific remediative measures. Additionally, the TSC might on its own accord engage with an IG to address potential alignment issues.
 


### PR DESCRIPTION
I've taken a cut at modifying our TSC Charter and Code of Conduct so they reflect changes we've discussed in recent Board meetings, specifically:

- Adjusted language in the TSC Charter to make clear that all SIG business is to be conducted in public, and to add the stipulation that no one may be nominated to the TSC if they are employed by an organization operating under US export sanctions.
- Made language in the CoC more specific about the "CoC Team" by adding a new section to establish the nature and membership of that team (TSC plus Executive Director acting as Compliance Officer) , and making sure other parts of the document say "CoC Team" (with a capital 'T') as a reference to that section

The first change is important in aligning with similar language recently added to the Bytecode Alliance bylaws, and the second one would resolve Issue #33 raised against the CoC.

David