### PR TITLE
Add Guy Bedford as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -8,6 +8,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 
 ## A-E
 
+Bedford, Guy ([@buybedford](https://github.com/buybedford))  
 Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))  
 bjorn3 ([@bjorn3](https://github.com/bjorn3))  
 Bordado, Afonso ([@afonso360](https://github.com/afonso360))  


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Guy Bedford
**GitHub Username:** guybedford
**Projects/SIGs:**
- https://github.com/bytecodealliance/jco
- https://github.com/bytecodealliance/componentize-js
- https://github.com/bytecodealliance/WASI-Virt
- https://github.com/bytecodealliance/wasm-tools
- https://github.com/bytecodealliance/SIG-Guest-Languages

## Nomination
Guy has made extensive contributions to a number of Bytecode Alliance projects; is the key maintainer of some, such as JCO and componentize-js; and is a co-lead of the SIG-Guest-Languages.

## Optional: Endorsements
<!--
List endorsements in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Till Schneidereit (@tschneidereit)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)