### PR TITLE
Append to SIG docs supporters

### DIFF
--- a/SIGs/SIG-documentation/proposal.md
+++ b/SIGs/SIG-documentation/proposal.md
@@ -12,5 +12,7 @@ As an immediate deliverable of the SIG, the group will produce and maintain cent
 
 The following individuals support the creation of SIG-Documentation:
 
-- Lopez, Daniel @vomkriege
 - Hayes, Bailey @ricochet (Cosmonic)
+- Lopez, Daniel @vomkriege
+- Wagner, Luke @lukewagner (Fastly)
+- Woods, Chris @woodsmc (Siemens)


### PR DESCRIPTION
As a delayed followup to https://github.com/bytecodealliance/governance/pull/45, adds the names of other members that supported the SIG proposal