### PR TITLE
Add Jake Champion as a recognised contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -16,6 +16,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Butcher, Matt ([@technosophos](https://github.com/technosophos))
 * Cabrera, Javier ([@Jacarte](https://github.com/Jacarte))
 * Cabrera, Saúl ([@saulecabrera](https://github.com/saulecabrera))
+* Champion, Jake ([@JakeChampion](https://GitHub.com/jakechampion))
 * Clark, Lin ([@linclark](https://github.com/linclark))
 * Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))
 * Delendik, Yury ([@yurydelendik](https://github.com/yurydelendik))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Jake Champion 
**GitHub Username:** @jakechampion
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->

## Nomination
I work on wasi and wasi-http related projects for my employer Fastly and their product named Fastly Compute, and work closely with Bytecode Alliance members. Most recently I've worked on wasi-http proxy component implementations and feeding back to the wasi-http wit definitions

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- 

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)