### PR TITLE
Add yosh wuyts to recognized contributors

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -81,6 +81,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Watt, Conrad ([@conrad-watt](https://github.com/conrad-watt))
 * Weigand, Ulrich ([@uweigand](https://github.com/uweigand))
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
+* Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))
 * Xu Jun ([@xujuntwt95329](https://github.com/xujuntwt95329))
 * Xu Xiong ([@venus-taibai](https://github.com/venus-taibai))
 * YAMAMOTO Takashi ([@yamt](https://github.com/yamt))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).
 
 **Name:** Yosh Wuyts
 **GitHub Username:** @yoshuawuyts
 **Projects/SIGs:**
 
## Nomination
I work on WASI, jco, and the Rust WASI toolchain on behalf of Microsoft. For the past two years I've been consulting on a variety of topics relating to WASI's design. And since the beginning of this year I've taken a more active role in contributing to WASI's development.

My primary expertise centers around async computing: I'm a current member of the Rust Async WG, and a former member of the Node.js Streams WG. I am also a former member of the (now inactive) Rust WebAssembly WG, which worked on platform-specific binding tools for WebAssembly predating WASI.
 
## Optional: Endorsements
 * [x]  I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)
