### PR TITLE
Add Timmy Silesmo as a recognised contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -62,6 +62,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))
 * Sharp, Jamey ([@jameysharp](https://github.com/jameysharp))
+* Silesmo, Timmy ([@silesmo](https://github.com/silesmo))
 * Sinclair, Rainy ([@itsrainy](https://github.com/itsrainy))
 * Spencer, Oscar ([@ospencer](https://github.com/ospencer))
 * Squillace, Ralph ([@squillace](https://github.com/squillace))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Timmy Silesmo
GitHub Username: @silesmo
Projects/SIGs:

### Nomination

As part of my role for nor2 I have contributed to the wit-bindgen implementation for C# as well as organizing the C# guest languages sub-group, contributed to the implementation of resources in wit-bindgen for wasmtime and wasm-tools as part of the Component model SIG. I have also added registry metadata support to wasm-tools as part of the Registries SIG.

### Optional: Endorsements

   - [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)