### PR TITLE
Add Eduardo Rodrigues as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -59,6 +59,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Penzin, Petr ([@penzn](https://github.com/penzn))
 * Prewitt, Calvin ([@calvinrp](https://github.com/calvinrp))
 * Qin Xiaokang ([@qinxk-inter](https://github.com/qinxk-inter))
+* Rodrigues, Eduardo ([@eduardomourar](https://github.com/eduardomourar))
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))
 * Sharp, Jamey ([@jameysharp](https://github.com/jameysharp))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Eduardo Rodrigues
GitHub Username: @eduardomourar
Projects/SIGs:

Nomination
-----
I work on WASI related projects and work closely with Bytecode Alliance members. Most recently I've worked on wasi-http implementations within wasmtime as well as the [WIT IDL for VSCode](https://github.com/bytecodealliance/vscode-wit#wit-idl-for-vscode).

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)