### PR TITLE
Add Kate Goldenring as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -29,6 +29,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Freyler, Robin ([@robbepop](https://github.com/robbepop))
 * Galli, Enrico ([@egalli](https://github.com/egalli))
 * Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))
+* Goldenring, Kate ([@kate-goldenring](https://github.com/kate-goldenring))
 * Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))
 * Hayes, Bailey ([@ricochet](https://github.com/ricochet))
 * He Jie ([@jhe33](https://github.com/jhe33))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Kate Goldenring
**GitHub Username:** @kate-goldenring
**Projects/SIGs:**
- [Component Docs](https://github.com/bytecodealliance/component-docs)

## Nomination
I nominate Kate because of her amazing contributions to the Component Docs project, and her work on supporting others during the Componentize The World event.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)