### PR TITLE
Add Ivan Towlson as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -41,6 +41,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Huang Wenyong ([@wenyongh](https://github.com/wenyongh))
 * Huene, Peter ([@peterhuene](https://github.com/peterhuene))
 * Hunt, Ryan ([@eqrion](https://github.com/eqrion))
+* Towlson, Ivan ([@itowlson](https://github.com/itowlson))
 * iximeow ([@iximeow](https://github.com/iximeow))
 * Johnson, Evan ([@enjhnsn2](https://github.com/enjhnsn2))
 * Jones, Brian J ([@brianjjones](https://github.com/brianjjones))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Ivan Towlson
**GitHub Username:** @itowlson
**Projects/SIGs:**
- [Component Docs](https://github.com/bytecodealliance/component-docs)

## Nomination
I nominate Ivan because of his amazing contributions to the Component Docs project, and his work on supporting others during the Componentize The World event.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)