### PR TITLE
Add Ryan Levick as an RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -47,6 +47,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Kirilov, Anton ([@akirilov-arm](https://github.com/akirilov-arm))
 * Kolny, Marcin ([@loganek](https://github.com/loganek))
 * Kulakowski, George ([@kulakowski-wasm](https://github.com/kulakowski-wasm))
+* Levick, Ryan ([@rylev](https://github.com/rylev/))
 * Liang Tianlong ([@TianlongLiang](https://github.com/TianlongLiang))
 * Macovei, Daniel ([macovedj](https://github.com/macovedj))
 * martin, katelyn ([@cratelyn](https://github.com/cratelyn))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Ryan Levick
**GitHub Username:** @rylev
**Projects/SIGs:**
- [Component Docs](https://github.com/bytecodealliance/component-docs)

## Nomination
I nominate Ryan because of his many contributions to Wasmtime, wasm-tools, wit-bindgen, and other projects.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)