### PR TITLE
Add Tyler Rockwood as rc

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -64,6 +64,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Penzin, Petr ([@penzn](https://github.com/penzn))
 * Prewitt, Calvin ([@calvinrp](https://github.com/calvinrp))
 * Qin Xiaokang ([@qinxk-inter](https://github.com/qinxk-inter))
+* Rockwood, Tyler ([@rockwotj](https://github.com/rockwotj))
 * Rodrigues, Eduardo ([@eduardomourar](https://github.com/eduardomourar))
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Tyler Rockwood
**GitHub Username:** @rockwotj
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- wasmtime

## Nomination

Tyler has made major improvements and contributions to wasmtime's C API.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)