### PR TITLE
Add Divya as recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -58,6 +58,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Matei, Radu ([@radu](https://github.com/radu-matei))
 * McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))
 * Mikushin, Ivan ([@imikushin](https://github.com/imikushin))
+* Mohan, Divya ([@divya-mohan0209](https://github.com/divya-mohan0209))
 * Narayan, Shravan ([@shravanrn](https://github.com/shravanrn))
 * Noorali, Michelle ([@michelleN](https://github.com/michelleN))
 * Parker, Sam ([@sparker-arm](https://github.com/sparker-arm))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Divya Mohan
**GitHub Username:** @divya-mohan0209
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- SIG-Documentation
- JCO

## Nomination

Divya has made several contributions to documentation for component docs and JCO.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)