### PR TITLE
Add Karen Chu as recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -19,6 +19,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Cabrera, Saúl ([@saulecabrera](https://github.com/saulecabrera))
 * Champion, Jake ([@JakeChampion](https://GitHub.com/jakechampion))
 * Chegham, Wassim ([@manekinekko](https://github.com/manekinekko))
+* Chu, Karen ([karenchu](https://github.com/karenhchu))
 * Clark, Lin ([@linclark](https://github.com/linclark))
 * Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))
 * Delendik, Yury ([@yurydelendik](https://github.com/yurydelendik))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Karen Chu
**GitHub Username:** @karenhchu

## Nomination

Karen has been part of building the Bytecode Alliance community by helping organize events like the BA Componentize The World event.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)