### PR TITLE
Add Scott Waye as rc

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -86,6 +86,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Wang Ning ([@wustwn](https://github.com/wustwn))
 * Wang Xin ([@xwang98](https://github.com/xwang98))
 * Watt, Conrad ([@conrad-watt](https://github.com/conrad-watt))
+* Waye, Scott ([@yowl](https://github.com/yowl))
 * Weigand, Ulrich ([@uweigand](https://github.com/uweigand))
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
 * Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Scott Waye
**GitHub Username:** @yowl
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- SIG Guest Languages - C#/.NET SG

## Nomination

Scott is a founding member of the C#/.NET SG of SIG Guest Languages. His contributions include expanding WASI support to .NET. 

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)