### PR TITLE
Add jsturtevant as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -73,6 +73,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Spencer, Oscar ([@ospencer](https://github.com/ospencer))
 * Squillace, Ralph ([@squillace](https://github.com/squillace))
 * Stefan, Deian ([@deian](https://github.com/deian))
+* Sturtevant, James ([@jsturtevant](https://github.com/jsturtevant))
 * Sun, Mingqiu ([@mingqiusun](https://github.com/mingqiusun))
 * Sverre, Carl ([@carlsverre](https://github.com/carlsverre))
 * Tang Wei ([@wei-tang](https://github.com/wei-tang))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** James Sturtevant
**GitHub Username:** @jsturtevant
**Projects/SIGs:**
- [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen)

## Nomination
I nominate James because of his many contributions to wit-bindgen, in particular the work on the C# bindings generator.

## Optional: Endorsements
<!--
List endorsements in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)