### PR TITLE
Add dhil as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -38,6 +38,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * He Liang ([@lum1n0us](https://github.com/lum1n0us))
 * Heaton, Damian ([@dheaton-arm](https://github.com/dheaton-arm))
 * Hickey, Pat ([@pchickey](https://github.com/pchickey))
+* Hillerström, Daniel ([@dhil](https://github.com/dhil))
 * Holley, Bobby ([@bholley](https://github.com/bholley))
 * Hoyer, Harald ([@haraldh](https://github.com/haraldh))
 * Huang Qi ([@no1wudi](https://github.com/no1wudi))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Daniel Hillerström
**GitHub Username:** @dhil
**Projects/SIGs:**
- [WasmFX](https://wasmfx.dev/)

## Nomination
I nominate Daniel because of his work on WasmFX. While WasmFX itself isn't a Bytecode Alliance project, the implementation based on Wasmtime, and more fundamentally the work towards adding effect handlers to WebAssembly, is thoroughly in line with BA goals. Additionally, in working on WasmFX Daniel has over time made contributions of various kinds to Wasmtime itself.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)