### PR TITLE
Add liamrandall as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -64,6 +64,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Penzin, Petr ([@penzn](https://github.com/penzn))
 * Prewitt, Calvin ([@calvinrp](https://github.com/calvinrp))
 * Qin Xiaokang ([@qinxk-inter](https://github.com/qinxk-inter))
+* Randall, Liam ([@liamrandall](https://github.com/liamrandall))
 * Rodrigues, Eduardo ([@eduardomourar](https://github.com/eduardomourar))
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Liam Randall
**GitHub Username:** @liamrandall
**Projects/SIGs:**

## Nomination
I nominate Liam because of his many contributions to organizing events such as the BA Plumbers Summit and Componentize The World, as well as general outreach and organization for the BA.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes  (@ricochet)

- [ ] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)