### PR TITLE
Add JamesMenetrey as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -58,6 +58,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Martin, Lann ([@lann](https://github.com/lann))
 * Matei, Radu ([@radu](https://github.com/radu-matei))
 * McCallum, Nathaniel ([@npmccallum](https://github.com/npmccallum))
+* Menetrey, James ([@JamesMenetrey](https://github.com/JamesMenetrey))
 * Mikushin, Ivan ([@imikushin](https://github.com/imikushin))
 * Narayan, Shravan ([@shravanrn](https://github.com/shravanrn))
 * Noorali, Michelle ([@michelleN](https://github.com/michelleN))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: James Menetrey 
**GitHub Username**: @JamesMenetrey 
**Projects/SIGs**:   [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)  
**Nomination**
I nominate James because of his many contributions to WAMR, in particular the work on the wasi support for SGX.

Optional: Endorsements


 I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)