### PR TITLE
Add tonibofarull to RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -78,6 +78,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Sverre, Carl ([@carlsverre](https://github.com/carlsverre))
 * Tang Wei ([@wei-tang](https://github.com/wei-tang))
 * Thomas, Taylor ([@thomastaylor312](https://github.com/thomastaylor312))
+* tonibofarull ([@tonibofarull](https://github.com/tonibofarull))
 * Triplett, Josh ([@joshtriplett](https://github.com/joshtriplett))
 * Turner, Aaron ([@torch2424](https://github.com/torch2424))
 * Turon, Aaron ([@aturon](https://github.com/aturon))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**:  tonibofarull 
**GitHub Username**:  @tonibofarull 
**Projects/SIGs**:   [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)  
**Nomination**
I nominate tonibofarull because of his many contributions to WAMR, in particular the work on the wasi-nn support.

Optional: Endorsements
YAMAMOTO Takashi(@yamt)

 I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

@tonibofarull: could you please give your full name so we can update the nomination text?