### PR TITLE
Add zoraaver as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -96,4 +96,4 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Yan Dongsheng ([@dongsheng28849455](https://github.com/dongsheng28849455))
 * Zang Lin ([@linzang](https://github.com/linzang))
 * Zhou, Jiaxiao ([@mossaka](https://github.com/mossaka))
-* zoraaver ([@zoraaver](https://github.com/zoraaver))
+* Singh, Zoraaver ([@zoraaver](https://github.com/zoraaver))

--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -96,3 +96,4 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Yan Dongsheng ([@dongsheng28849455](https://github.com/dongsheng28849455))
 * Zang Lin ([@linzang](https://github.com/linzang))
 * Zhou, Jiaxiao ([@mossaka](https://github.com/mossaka))
+* zoraaver ([@zoraaver](https://github.com/zoraaver))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: zoraaver 
**GitHub Username**: @zoraaver 
**Projects/SIGs**:   [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)  
**Nomination**
I nominate zoraaver because of his many contributions to WAMR, in particular the work on the wasi support and Windows platform support.

Optional: Endorsements  
Marcin Kolny (@loganek)

 I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

@zoraaver Could you please give your full name so we can update the nomination text?