### PR TITLE
Add Maks Litskevich as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -53,6 +53,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Kulakowski, George ([@kulakowski-wasm](https://github.com/kulakowski-wasm))
 * Levick, Ryan ([@rylev](https://github.com/rylev/))
 * Liang Tianlong ([@TianlongLiang](https://github.com/TianlongLiang))
+* Litskevich, Maks ([@Zzzabiyaka](https://github.com/Zzzabiyaka))
 * Macovei, Daniel ([macovedj](https://github.com/macovedj))
 * martin, katelyn ([@cratelyn](https://github.com/cratelyn))
 * Martin, Lann ([@lann](https://github.com/lann))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: Maks Litskevich
**GitHub Username**: @Zzzabiyaka
**Projects/SIGs**:   [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)  
**Nomination**
I nominate Maks because of his many contributions to WAMR.

Optional: Endorsements  
Marcin Kolny (@loganek)

 I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)