### PR TITLE
Add Jimmy Bourassa as a RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -11,6 +11,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))
 * bjorn3 ([@bjorn3](https://github.com/bjorn3))
 * Bordado, Afonso ([@afonso360](https://github.com/afonso360))
+* Bourassa, Jimmy ([@jbourassa](https://github.com/jbourassa))
 * Bouvier, Benjamin ([@bnjbvr](https://github.com/bnjbvr))
 * Brown, Andrew ([@abrown](https://github.com/abrown))
 * Brown, Robin ([@esoterra](https://github.com/esoterra))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: Jimmy Bourassa
**GitHub Username**: @jbourassa
**Projects**: [wasmtime-rb](https://github.com/bytecodealliance/wasmtime-rb)

## Nomination
I nominate Jimmy Bourassa due to all of his contributions to `wasmtime-rb`. 


I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

