### PR TITLE
Add Ian Ker-Seymer as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -49,6 +49,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * iximeow ([@iximeow](https://github.com/iximeow))
 * Johnson, Evan ([@enjhnsn2](https://github.com/enjhnsn2))
 * Jones, Brian J ([@brianjjones](https://github.com/brianjjones))
+* Ker-Seymer, Ian ([ianks](https://github.com/ianks))
 * Kirilov, Anton ([@akirilov-arm](https://github.com/akirilov-arm))
 * Kolny, Marcin ([@loganek](https://github.com/loganek))
 * Kulakowski, George ([@kulakowski-wasm](https://github.com/kulakowski-wasm))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: Ian Ker-Seymer
**GitHub Username**: @ianks
**Projects**: [wasmtime-rb](https://github.com/bytecodealliance/wasmtime-rb)

## Nomination
I nominate Ian Ker-Seymer because of his continuous contributions and improvements to `wasmtime-rb`.  


I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)