### PR TITLE
Add Jeff Charles as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -18,6 +18,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Cabrera, Javier ([@Jacarte](https://github.com/Jacarte))
 * Cabrera, Saúl ([@saulecabrera](https://github.com/saulecabrera))
 * Champion, Jake ([@JakeChampion](https://GitHub.com/jakechampion))
+* Charles, Jeff ([@jeffcharles](https://github.com/jeffcharles))
 * Chegham, Wassim ([@manekinekko](https://github.com/manekinekko))
 * Clark, Lin ([@linclark](https://github.com/linclark))
 * Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name**: Jeff Charles
**GitHub Username**: @jeffcharles
**Projects**: [Javy](https://github.com/bytecodealliance/javy), [Winch](https://github.com/bytecodealliance/wasmtime/tree/main/winch)

## Nomination
I nominate Jeff Charles because of his continuous contributions and improvements to Javy and Winch. 


I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)