### PR TITLE
Add Catherine whitequark as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -104,6 +104,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Watt, Conrad ([@conrad-watt](https://github.com/conrad-watt))
 * Waye, Scott ([@yowl](https://github.com/yowl))
 * Weigand, Ulrich ([@uweigand](https://github.com/uweigand))
+* whitequark, Catherine ([@whitequark](https://github.com/whitequark))
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
 * Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))
 * Xu Jun ([@xujuntwt95329](https://github.com/xujuntwt95329))


### PR DESCRIPTION
I am self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Catherine (whitequark)
**GitHub Username:** whitequark
**Projects/SIGs:** Unaffiliated

## Nomination
I work on FPGA toolchains, and I use WebAssembly to deliver them, by way of the [YoWASP](https://yowasp.org) project, to the [Python](https://pypi.org/search/?q=yowasp) and [JavaScript](https://npmjs.org/org/yowasp) ecosystems, as well as [VS Code](https://marketplace.visualstudio.com/items?itemName=yowasp.toolchain). I have contributed to core Bytecode Alliance projects (wasmtime, wasi-libc, WASI-Virt) before, and I plan to continue working with BA to improve the position of WebAssembly as a toolchain delivery platform and in related applications.

## Endorsements
- Pat Hickey (@pchickey)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)