### PR TITLE
Update SIG materials

### DIFF
--- a/SIGs/README.md
+++ b/SIGs/README.md
@@ -11,7 +11,7 @@ A Interest Group is a group of Bytecode Alliance members (and invited participan
 ## Current SIGs
 Currently active Bytecode Alliance SIGs (and their respective Chairpersons) include:
 * SIG Registries (Robin Brown and Calvin Prewitt, Co-chairs)
-* SIG Guest Languages (Robin Brown, Chair)
+* SIG Guest Languages (Robin Brown and Guy Bedford, Co-chairs)
   * JavaScript Working Group  (Saúl Cabrera and Calvin Prewitt, Co-chairs)
   * C# Working Group (Timmy Silesmo, Chair)
   * Python Working Group (Joel Dice, Chair)

--- a/SIGs/README.md
+++ b/SIGs/README.md
@@ -1,0 +1,28 @@
+# Special Interest Groups
+
+The Bytecode Alliance is focused on creating secure, foundational technology for WebAssembly, including WASI. However, it’s become clear that there is significant community interest in discussions around the application of that technology to vertical use cases.
+
+To accommodate those discussions and assure that the community’s valuable feedback can be channeled into the Bytecode Alliance’s core functions, the charter for the Technical Steering Committee (TSC) empowers it to authorize and oversee Interest Groups.
+
+## What is an Interest Group?
+
+A Interest Group is a group of Bytecode Alliance members (and invited participants; see below) who share an interest in a particular application or aspect of the technology that the Bytecode Alliance is working on. IGs serve as a channel for practitioners and users of BA technology to give feedback and input to the development of its technology, as well as a space for them to discuss how to use it.
+
+## Current SIGs
+Currently active Bytecode Alliance SIGs (and their respective Chairpersons) include:
+* SIG Registries (Robin Brown and Calvin Prewitt, Co-chairs)
+* SIG Guest Languages (Robin Brown, Chair)
+  * JavaScript Working Group  (Saúl Cabrera and Calvin Prewitt, Co-chairs)
+  * C# Working Group (Timmy Silesmo, Chair)
+  * Python Working Group (Joel Dice, Chair)
+  * Go Working Group (Jiaxiao Zhou, Chair)
+* SIG Typescript Compilation (Wang Xin, Chair)
+* SIG Debugging (Nick Fitzgerald, Chair)
+* SIG Documentation (Kate Goldenring and Danniel Macovei, Co-chairs)
+
+Each SIG is described in more detail in subfolders in this repository
+
+# Learn More
+If you're looking for information on SIG meetings and associated activities you'll find the relevant details in the Bytecode Alliance [meetings repository](https://github.com/bytecodealliance/meetings).
+
+If you're interested in forming an Interest Group you'll find more information in the [TSC charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) as well as a [Getting Started Guide](https://github.com/bytecodealliance/governance/blob/main/SIGs/getting-started-guide.md) here.

--- a/SIGs/getting-started-guide.md
+++ b/SIGs/getting-started-guide.md
@@ -1,0 +1,46 @@
+# How to Create and Kickoff a Special Interest Group (SIG)
+
+## Proposing a SIG
+
+As explained in the Bytecode Alliance [Technical Steering Committee charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#creating-an-interest-group), any member of the Bytecode Alliance can propose the creation of an Interest Group. 
+- [ ] Write a proposal to create the SIG, clearly identifing its scope and goals, and list the member(s) supporting its creation.  It is helpful to also have the proposal suggest willing Chairpersons for the SIG. 
+- [ ] Submit the proposal as a pull request to the `SIGs` directory of [the `governance` repository of the Bytecode Allicance GitHub organization](https://github.com/bytecodealliance/governance/tree/main/SIGs) with a request for members to comment to be added as a supporting member to the proposal. TSC has the approval authority for the SIG. For an example, see the [SIG-docs pull request](https://github.com/bytecodealliance/governance/pull/45).
+- [ ] The TSC will consider the proposal and make a decision in a reasonable timeframe. It may adopt the proposal as made, but it can also modify the proposal if it believes it necessary. If approved the TSC will formally appoint one or more Chairs, who should follow the steps below to establish the SIG. 
+
+## Establishing a SIG
+
+Bytecode Alliance SIGs operate transparently and in full public view, open to participation by all. Approved SIGs therefore require a variety of resources to support their operation. For help with any of these contact David Bryant, Bytecode Alliance Executive Director, at david@bytecodealliance.org
+
+- [ ] Create a Google Group for the SIG within the Bytecode Alliance Google Workspace, allowing easy communication and sharing of materials among SIG members
+- [ ] Create a subfolder for the SIG in the SIGs folder of the Bytecode Alliance [governance](https://github.com/bytecodealliance/governance/tree/main/SIGs) repository 
+    - [ ] Add the approved proposal for the SIG to its subfolder, making sure the stated scope, goals, and members are up to date.
+    - [ ] Update the README in the overall SIGs subfolder to include the new SIG with its Chair(s).
+- [ ] Ensure SIG Chairs are added to the [`sig-admin`](https://groups.google.com/u/1/a/bytecodealliance.org/g/sig-admin) Google Group to get admin information and access, such as in organizing Zoom meetings, access meeting recordings, update the Bytecode Alliance public calendar, etc.
+- [ ] Create a  channel for the SIG on the Bytecode Alliance [`Zulip server`](https://bytecodealliance.zulipchat.com)
+- [ ] Add SIG Chairs as maintainers to the Bytecode Alliance [`meetings`](https://github.com/bytecodealliance/meetings) repository so they can manage a subfolder there for the SIG's meeting agenda, notes, presentations, etc.
+    - [ ] Create the subfolder for the SIG, and add a README that summarizes general information about attending SIG meetings.
+    - [ ] Update the README in the [`meetings`](https://github.com/bytecodealliance/meetings) repo to include the new SIG. As soon as the SIG Chair(s) are appointed please identify them in the repo README as well.
+    - [ ] Add meeting agegnda and notes to the subfolder as meetings are planned and occur, typically organized by year.
+- [ ] Add SIG meetings to the Bytecode Alliance [public calendar](https://calendar.google.com/calendar/embed?src=events%40bytecodealliance.org&ctz=America%2FLos_Angeles). Include important details on joining the meeting or a link to where those details may be found.
+- [ ] Announce the new SIG on Zulip in `#general`
+
+## Running SIG Meetings
+
+The following are minimum requirements of running a SIG:
+
+- All meetings should be public
+- Attendance and notes should be taken at all meetings
+- Meetings should be recorded if practical and uploaded to Bytecode Alliance YouTube in a new channel for the SIG. Note, check "No it is not made for kids" when uploaded.
+- Meeting notes should publicly available and easy to find, either by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.
+
+
+The Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all its SIGs.
+
+## Co-chair onboarding
+- [ ] Add to `sig-admins` Google Group
+- [ ] Add to the Bytecode Alliance 1Password Team account so can access:
+    - SIG Admin Zoom credentials to manage video meetings and meeting recordings
+    - YouTube credentials to upload videos
+    - Public Events calendar to schedule and maintain SIG meetings
+
+


### PR DESCRIPTION
In order to expedite and streamline formation of new Special Interest Groups, of which we have several in active discussion, I've worked with our TSC and the new SIG Documentation team to prepare an overview on SIG formation entitled "How to Create and Kickoff a Special Interest Group (SIG)".  That document provides checklists both for getting new SIG proposals submitted for review and, if approved, the steps needed to get a new SIG up and running consistent with our best practices for participation and transparency.  As such it should be part of the SIGs subfolder here.

Also, I've added a README to the SIGs subfolder recapping our current SIGs and their chairpersons, along with info on where to go to find out more as a way of helping people get acquainted and involved.