### PR TITLE
Update and improve the SIG getting started guide

### DIFF
--- a/SIGs/README.md
+++ b/SIGs/README.md
@@ -11,12 +11,13 @@ A Interest Group is a group of Bytecode Alliance members (and invited participan
 ## Current SIGs
 
 Currently active Bytecode Alliance SIGs (and their respective Chairpersons) include:
-* SIG Registries (Robin Brown and Calvin Prewitt, Co-chairs)
+* SIG Registries (Lann Martin and Calvin Prewitt, Co-chairs)
 * SIG Guest Languages (Robin Brown and Guy Bedford, Co-chairs)
-  * JavaScript Working Group  (Saúl Cabrera and Calvin Prewitt, Co-chairs)
-  * C# Working Group (Timmy Silesmo, Chair)
-  * Python Working Group (Joel Dice, Chair)
-  * Go Working Group (Jiaxiao Zhou, Chair)
+  * JavaScript Subgroup  (Saúl Cabrera and Calvin Prewitt, Co-chairs)
+  * C# Subgroup (Timmy Silesmo, Chair)
+  * Python Subgroup (Joel Dice, Chair)
+  * Go Subgroup (Jiaxiao Zhou, Chair)
+  * Rust Subgroup (Peter Huene and Alex Crichton, Co-chairs)
 * SIG Typescript Compilation (Wang Xin, Chair)
 * SIG Debugging (Nick Fitzgerald, Chair)
 * SIG Documentation (Kate Goldenring and Danniel Macovei, Co-chairs)

--- a/SIGs/README.md
+++ b/SIGs/README.md
@@ -21,6 +21,7 @@ Currently active Bytecode Alliance SIGs (and their respective Chairpersons) incl
 * SIG Typescript Compilation (Wang Xin, Chair)
 * SIG Debugging (Nick Fitzgerald, Chair)
 * SIG Documentation (Kate Goldenring and Danniel Macovei, Co-chairs)
+* SIG Community (Karen Chu and Divya Mohan, Co-chairs)
 
 Each SIG is described in more detail in subfolders in this repository
 

--- a/SIGs/getting-started-guide.md
+++ b/SIGs/getting-started-guide.md
@@ -30,7 +30,7 @@ The following are minimum requirements of running a SIG:
 
 - All meetings must be public. The zoom link need not be publicly available, to avoid zoom bombing, but should be shared with anyone who requests it.
 - Attendance and notes should be taken at all meetings
-- It is recommended, but not requied, that meetings be recorded and uploaded to Bytecode Alliance YouTube in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
+- It is recommended, but not required, that meetings be recorded and uploaded to Bytecode Alliance [YouTube channel](https://www.youtube.com/@bytecodealliance) in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
 - Meeting notes must be publicly available and easy to find, either by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.
 
 The Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all its SIGs.

--- a/SIGs/getting-started-guide.md
+++ b/SIGs/getting-started-guide.md
@@ -35,8 +35,6 @@ Bytecode Alliance SIGs operate transparently and in full public view, open to pa
 
 ## Running SIG Meetings
 
-In addition to the `meetings` repository mentioned above for publishing meeting agenda and minutes, the Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all SIGs, and a YouTube account for sharing meeting recordings publicly.
-
 The following are minimum requirements of running a SIG:
 
 - All meetings must be public.  The Zoom link need not be publicly available to avoid Zoom bombing, but should be shared with anyone who requests it.
@@ -44,3 +42,5 @@ The following are minimum requirements of running a SIG:
 - It is recommended, but not required, that meetings be recorded and uploaded to Bytecode Alliance [YouTube channel](https://www.youtube.com/@bytecodealliance) in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
 - Meeting notes must be publicly available and easy to find, ideally by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.
 - Conversations about meetings should take place in the SIG's stream on Zulip, including discussion of agenda topics, proposals to move/cancel a meeting, or important changes in meeting logistics.
+
+In addition to the `meetings` repository mentioned above for publishing meeting agenda and minutes, the Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all SIGs, and a YouTube account for sharing meeting recordings publicly.

--- a/SIGs/getting-started-guide.md
+++ b/SIGs/getting-started-guide.md
@@ -12,18 +12,18 @@ As explained in the Bytecode Alliance [Technical Steering Committee charter](htt
 Bytecode Alliance SIGs operate transparently and in full public view, open to participation by all. Approved SIGs therefore require a variety of resources to support their operation. For help with any of these contact David Bryant, Bytecode Alliance Executive Director, at david@bytecodealliance.org
 
 ### On GitHub
-- [ ] **Governance** Create a subfolder for the new SIG in the SIGs folder of the Bytecode Alliance [governance](https://github.com/bytecodealliance/governance/tree/main/SIGs) repository, making its existence and purpose officially public. 
+- [ ] **Governance** - Create a subfolder for the new SIG in the SIGs folder of the Bytecode Alliance [governance](https://github.com/bytecodealliance/governance/tree/main/SIGs) repository, making its existence and purpose officially public. 
     - [ ] Add the approved proposal for the SIG to its subfolder, making sure the stated scope, goals, and members are up to date.
     - [ ] Update the README in the overall SIGs subfolder to include the new SIG with its Chair(s).
-- [ ] **Meetings** Create a subfolder for the new SIG in the Bytecode Alliance [`meetings`](https://github.com/bytecodealliance/meetings) repository, giving it a place to share important meeting info as well as gather meeting agenda and minutes.  This gives the SIG Chairs access to create and update all the SIGs meeting information in the `meetings` repo.
-    - [ ] Create a new GitHub [team](https://github.com/orgs/bytecodealliance/teams) for the approved SIG Chairs, as a subteam of the existing `sig-chairs` GitHub team, and give that new team access to the SIGs subfolder in the `meetings` repository (via the `CODEOWNERS` file in the repo).
-    - [ ] Add a README to the SIG's subfolder summarizing general information about attending SIG meetings.
+- [ ] **Meetings** - Create a subfolder for the new SIG in the Bytecode Alliance [`meetings`](https://github.com/bytecodealliance/meetings) repository, giving it a place to share important meeting information as well as gather meeting agenda and minutes.  
+    - [ ] Create a new GitHub [team](https://github.com/orgs/bytecodealliance/teams) for the approved SIG Chairs, as a subteam of the existing `sig-chairs` GitHub team, and give that new team access to the SIGs subfolder in the `meetings` repository (via the `CODEOWNERS` file in the repo). This allows the SIG Chairs access to create and update all meeting information for the SIG.
+    - [ ] Add a README to the SIG subfolder summarizing general information about attending SIG meetings.
     - [ ] Update the README in the [`meetings`](https://github.com/bytecodealliance/meetings) repo to include the new SIG and identify the SIG Chairs
     - [ ] Add meeting agegnda and notes to the subfolder as meetings are planned and occur, typically organized by year.
 
 
 ### Communications
-- [ ] Ensure SIG Chairs are added to the [`sig-admin`](https://groups.google.com/u/1/a/bytecodealliance.org/g/sig-admin) Google Group to get admin information and access, such as in organizing Zoom meetings, access meeting recordings, update the Bytecode Alliance public calendar, etc.
+- [ ] Ensure SIG Chairs are added to the [`sig-admin`](https://groups.google.com/u/1/a/bytecodealliance.org/g/sig-admin) Google Group to get admin information and access, such as in organizing Zoom meetings, managing meeting recordings, updating the Bytecode Alliance public calendar, etc.
 - [ ] Create a Google Group for the SIG within the Bytecode Alliance Google Workspace, allowing easy communication and sharing of materials among SIG members. Make sure group permissions allow anyone on the web to ask to join.
 - [ ] Create a  channel for the SIG on the Bytecode Alliance [`Zulip server`](https://bytecodealliance.zulipchat.com)
 - [ ] Add SIG meetings to the Bytecode Alliance [public calendar](https://calendar.google.com/calendar/embed?src=events%40bytecodealliance.org&ctz=America%2FLos_Angeles). Include important details on joining the meeting or a link to where those details may be found.
@@ -35,11 +35,11 @@ Bytecode Alliance SIGs operate transparently and in full public view, open to pa
 
 ## Running SIG Meetings
 
-In addition to the `meetings` repository mentioned above for sharing meeting agenda and minutes, the Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all its SIGs. Meeting recordings are shared using the Bytecode Alliance's YouTube account.
+In addition to the `meetings` repository mentioned above for publishing meeting agenda and minutes, the Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all SIGs, and a YouTube account for sharing meeting recordings publicly.
 
 The following are minimum requirements of running a SIG:
 
-- All meetings must be public.  The Zoom link need not be publicly available, to avoid Zoom bombing, but should be shared with anyone who requests it.
+- All meetings must be public.  The Zoom link need not be publicly available to avoid Zoom bombing, but should be shared with anyone who requests it.
 - Attendance and notes should be taken at all meetings
 - It is recommended, but not required, that meetings be recorded and uploaded to Bytecode Alliance [YouTube channel](https://www.youtube.com/@bytecodealliance) in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
 - Meeting notes must be publicly available and easy to find, ideally by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.

--- a/SIGs/getting-started-guide.md
+++ b/SIGs/getting-started-guide.md
@@ -11,34 +11,36 @@ As explained in the Bytecode Alliance [Technical Steering Committee charter](htt
 
 Bytecode Alliance SIGs operate transparently and in full public view, open to participation by all. Approved SIGs therefore require a variety of resources to support their operation. For help with any of these contact David Bryant, Bytecode Alliance Executive Director, at david@bytecodealliance.org
 
-- [ ] Create a Google Group for the SIG within the Bytecode Alliance Google Workspace, allowing easy communication and sharing of materials among SIG members
-- [ ] Create a subfolder for the SIG in the SIGs folder of the Bytecode Alliance [governance](https://github.com/bytecodealliance/governance/tree/main/SIGs) repository 
+### On GitHub
+- [ ] **Governance** Create a subfolder for the new SIG in the SIGs folder of the Bytecode Alliance [governance](https://github.com/bytecodealliance/governance/tree/main/SIGs) repository, making its existence and purpose officially public. 
     - [ ] Add the approved proposal for the SIG to its subfolder, making sure the stated scope, goals, and members are up to date.
     - [ ] Update the README in the overall SIGs subfolder to include the new SIG with its Chair(s).
-- [ ] Ensure SIG Chairs are added to the [`sig-admin`](https://groups.google.com/u/1/a/bytecodealliance.org/g/sig-admin) Google Group to get admin information and access, such as in organizing Zoom meetings, access meeting recordings, update the Bytecode Alliance public calendar, etc.
-- [ ] Create a  channel for the SIG on the Bytecode Alliance [`Zulip server`](https://bytecodealliance.zulipchat.com)
-- [ ] Add SIG Chairs as maintainers to the Bytecode Alliance [`meetings`](https://github.com/bytecodealliance/meetings) repository so they can manage a subfolder there for the SIG's meeting agenda, notes, presentations, etc.
-    - [ ] Create the subfolder for the SIG, and add a README that summarizes general information about attending SIG meetings.
-    - [ ] Update the README in the [`meetings`](https://github.com/bytecodealliance/meetings) repo to include the new SIG. As soon as the SIG Chair(s) are appointed please identify them in the repo README as well.
+- [ ] **Meetings** Create a subfolder for the new SIG in the Bytecode Alliance [`meetings`](https://github.com/bytecodealliance/meetings) repository, giving it a place to share important meeting info as well as gather meeting agenda and minutes.  This gives the SIG Chairs access to create and update all the SIGs meeting information in the `meetings` repo.
+    - [ ] Create a new GitHub [team](https://github.com/orgs/bytecodealliance/teams) for the approved SIG Chairs, as a subteam of the existing `sig-chairs` GitHub team, and give that new team access to the SIGs subfolder in the `meetings` repository (via the `CODEOWNERS` file in the repo).
+    - [ ] Add a README to the SIG's subfolder summarizing general information about attending SIG meetings.
+    - [ ] Update the README in the [`meetings`](https://github.com/bytecodealliance/meetings) repo to include the new SIG and identify the SIG Chairs
     - [ ] Add meeting agegnda and notes to the subfolder as meetings are planned and occur, typically organized by year.
+
+
+### Communications
+- [ ] Ensure SIG Chairs are added to the [`sig-admin`](https://groups.google.com/u/1/a/bytecodealliance.org/g/sig-admin) Google Group to get admin information and access, such as in organizing Zoom meetings, access meeting recordings, update the Bytecode Alliance public calendar, etc.
+- [ ] Create a Google Group for the SIG within the Bytecode Alliance Google Workspace, allowing easy communication and sharing of materials among SIG members. Make sure group permissions allow anyone on the web to ask to join.
+- [ ] Create a  channel for the SIG on the Bytecode Alliance [`Zulip server`](https://bytecodealliance.zulipchat.com)
 - [ ] Add SIG meetings to the Bytecode Alliance [public calendar](https://calendar.google.com/calendar/embed?src=events%40bytecodealliance.org&ctz=America%2FLos_Angeles). Include important details on joining the meeting or a link to where those details may be found.
 - [ ] Announce the new SIG on Zulip in `#general`
-
-## Running SIG Meetings
-
-The following are minimum requirements of running a SIG:
-
-- All meetings must be public. The zoom link need not be publicly available, to avoid zoom bombing, but should be shared with anyone who requests it.
-- Attendance and notes should be taken at all meetings
-- It is recommended, but not required, that meetings be recorded and uploaded to Bytecode Alliance [YouTube channel](https://www.youtube.com/@bytecodealliance) in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
-- Meeting notes must be publicly available and easy to find, either by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.
-
-The Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all its SIGs.
-
-## Co-chair onboarding
-
-- [ ] Add to `sig-admins` Google Group
-- [ ] Add to the Bytecode Alliance 1Password Team account so can access:
+- [ ] Add SIG chairs to the Bytecode Alliance 1Password Team account so they can access:
     - SIG Admin Zoom credentials to manage video meetings and meeting recordings
     - YouTube credentials to upload videos
     - Public Events calendar to schedule and maintain SIG meetings
+
+## Running SIG Meetings
+
+In addition to the `meetings` repository mentioned above for sharing meeting agenda and minutes, the Bytecode Alliance maintains a Zoom account to enable video meeting support and recording for all its SIGs. Meeting recordings are shared using the Bytecode Alliance's YouTube account.
+
+The following are minimum requirements of running a SIG:
+
+- All meetings must be public.  The Zoom link need not be publicly available, to avoid Zoom bombing, but should be shared with anyone who requests it.
+- Attendance and notes should be taken at all meetings
+- It is recommended, but not required, that meetings be recorded and uploaded to Bytecode Alliance [YouTube channel](https://www.youtube.com/@bytecodealliance) in a playlist for the SIG. (Note: check "No it is not made for kids" when uploaded.)
+- Meeting notes must be publicly available and easy to find, ideally by including them in the SIG's subfolder in the [`meetings`](https://github.com/bytecodealliance/meetings) repo or, if elsewhere, directly linked to from within that subfolder.
+- Conversations about meetings should take place in the SIG's stream on Zulip, including discussion of agenda topics, proposals to move/cancel a meeting, or important changes in meeting logistics.


### PR DESCRIPTION
I've revised the organization and description of the steps in establishing a SIG in the getting started guide based on experience in enabling the new SIG Community, and to reflect some improvements in how we delegate access to SIG chairs within GitHub.  My aim is to provide something more usable as a self-contained task checklist, with tasks in an order that enables on boarding of SIG chairs so they can carry out those tasks and begin running the SIG.