### PR TITLE
Updating eSIG proposal Supporters

### DIFF
--- a/SIGs/SIG-embedded/proposal.md
+++ b/SIGs/SIG-embedded/proposal.md
@@ -150,3 +150,5 @@ As part of the work the SIG conducts it may be necessary for organizations to pr
 - Wenyong Huang (Intel) @wenyongh
 - Christof Petig (Aptiv) @cpetig
 - Petr Penzin @ppenzin
+- Ayako Akasaka (Midokura) @ayakoakasaka
+- Takashi Yamamoto (Midokura) @yamt


### PR DESCRIPTION
Midokura have asked that their support for the Embedded SIG be made visible to the public with two additional supporters. cc: 
@ayakoakasaka  @disquisitioner 