### PR TITLE
Add Emily Ruppel as Recognized Contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -79,6 +79,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Reddig, Randy ([@ydnar](https://github.com/ydnar))
 * Rockwood, Tyler ([@rockwotj](https://github.com/rockwotj))
 * Rodrigues, Eduardo ([@eduardomourar](https://github.com/eduardomourar))
+* Ruppel, Emily ([@kangaruppel](https://github.com/kangaruppel))
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))
 * Sharp, Jamey ([@jameysharp](https://github.com/jameysharp))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Emily Ruppel
**GitHub Username:** @kangaruppel

## Nomination

Emily has been part of the group setting up the SIG-Embedded and is serving as one of its co-chairs.

## Optional: Endorsements
- Till Schneidereit (@tschneidereit)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)