### PR TITLE
Add Xinzhao Xu as Recognized Contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -108,6 +108,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
 * Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))
 * Xu Jun ([@xujuntwt95329](https://github.com/xujuntwt95329))
+* Xu, Xinzhao ([@iawia002](https://github.com/iawia002))
 * Xu Xiong ([@venus-taibai](https://github.com/venus-taibai))
 * YAMAMOTO Takashi ([@yamt](https://github.com/yamt))
 * Yan Dongsheng ([@dongsheng28849455](https://github.com/dongsheng28849455))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Xinzhao Xu
**GitHub Username:** @iawia002 
**Projects/SIGs:** [wasmtime](https://github.com/bytecodealliance/wasmtime), [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen), [cargo-component](https://github.com/bytecodealliance/cargo-component)

## Nomination

I have contributed to [wasmtime](https://github.com/bytecodealliance/wasmtime), [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) and [cargo-component](https://github.com/bytecodealliance/cargo-component), including minor improvements, bug fixes, and implementation of WASI proposals like [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) and [wasi-keyvalue](https://github.com/WebAssembly/wasi-keyvalue).

## Optional: Endorsements

- Pat Hickey (@pchickey)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)