### PR TITLE
docs(rc): nominate Victor Adossi

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -6,6 +6,7 @@ To nominate a new Recognized Contributor, make a pull request adding the candida
 
 Format of entries: `Surname, First name (GitHub Username)`. When it is traditional to put surname first, the comma is omitted.
 
+* Adossi, Victor ([@vados-cosmonic](https://github.com/vados-cosmonic))
 * Bakker, Dave ([@badeend](https://github.com/badeend))
 * Bedford, Guy ([@guybedford](https://github.com/guybedford))
 * Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))


### PR DESCRIPTION
Signed-off-by: Bailey Hayes <behayes2@gmail.com>

I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Victor Adossi
**GitHub Username:** vados-cosmonic
**Projects/SIGs:**

<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- SIG Guest Langauges JS Subgroup
- Contributions to many Bytecode Alliance projects:
  - wasm-tools
  - component model book
  - wit-bindgen
  - wasmtime
  - JCO
  - ComponentizeJS

## Nomination
Victor was part of the effort to land the feature gate implementation in JCO which was critical for us to roll out the first WASI patch release in the Bytecode Alliance.

Victor has a focus on improving usability from creating examples and documentationto improves our projects with bug fixes and contributions. He regularly responds to new users asking for help on our Zulip and aids in growing our community.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)