### PR TITLE
docs(rc): nominate Eric Gregory

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -36,6 +36,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Galli, Enrico ([@egalli](https://github.com/egalli))
 * Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))
 * Goldenring, Kate ([@kate-goldenring](https://github.com/kate-goldenring))
+* Gregory, Eric ([ericgregory](https://github.com/ericgregory))
 * Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))
 * Hayes, Bailey ([@ricochet](https://github.com/ricochet))
 * He Jie ([@jhe33](https://github.com/jhe33))


### PR DESCRIPTION
I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Eric Gregory
**GitHub Username:** ericgregory
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- SIG Documentation
- Bytecode Alliance Blog
- wasi.dev
- component model book

## Nomination
Eric is one of the key contributors to our documentation and communications efforts and focuses most of his efforts within the Documentation SIG. In less than a year, he has contributed 6 articles to our Bytecode Alliance blog. He updated and revised wasi.dev, and has made several improvements the component model book.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)