### PR TITLE
docs(rc): nominate Keith Winstein

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -106,6 +106,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Waye, Scott ([@yowl](https://github.com/yowl))
 * Weigand, Ulrich ([@uweigand](https://github.com/uweigand))
 * whitequark, Catherine ([@whitequark](https://github.com/whitequark))
+* Winstein, Keith ([keithw](https://github.com/keithw))
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
 * Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))
 * Xu Jun ([@xujuntwt95329](https://github.com/xujuntwt95329))


### PR DESCRIPTION
I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Keith Winstein
**GitHub Username:** keithw
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- wasm-tools
- In the greater Wasm ecosystem, [WebAssembly/wabt](github.com/WebAssembly/wabt)

## Nomination
Keith is a long time member of our community whose focus is on moving WebAssembly proposals forward from custom page sizes, tail calls, to mem64. He's contributed to spec tests and is an excellent collaborator. 

Within Bytecode Alliance projects, he has made many improvements to Wasm printing and parsing in wasm-tools.

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)