### PR TITLE
Add Chris Woods as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -106,6 +106,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Waye, Scott ([@yowl](https://github.com/yowl))
 * Weigand, Ulrich ([@uweigand](https://github.com/uweigand))
 * whitequark, Catherine ([@whitequark](https://github.com/whitequark))
+* Woods, Chris ([woodsmc](https://github.com/woodsmc))  
 * Wu Zhongmin ([@sophy228](https://github.com/sophy228))
 * Wuyts, Yosh ([@yoshuawuyts](https://github.com/yoshuawuyts))
 * Xu Jun ([@xujuntwt95329](https://github.com/xujuntwt95329))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Chris Woods
GitHub Username: @woodsmc

Nomination
Chris has been proactively driving the WebAssembly development for industrial and embedded usages. He is part of the group setting up the SIG-Embedded and is serving as one of its co-chairs.

Optional: Endorsements
Xin Wang (@xwang98)

 I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)