### PR TITLE
Add Trenner, Thomas as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -94,6 +94,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Tamayo-Rios, Matthew ([@geekbeast](https://github.com/geekbeast))
 * Tang Wei ([@wei-tang](https://github.com/wei-tang))
 * Thomas, Taylor ([@thomastaylor312](https://github.com/thomastaylor312))
+* Trenner, Thomas ([ttrenner](https://github.com/ttrenner))  
 * Triplett, Josh ([@joshtriplett](https://github.com/joshtriplett))
 * Turner, Aaron ([@torch2424](https://github.com/torch2424))
 * Turon, Aaron ([@aturon](https://github.com/aturon))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Trenner, Thomas
GitHub Username: @ttrenner

Nomination
Thomas has been proactively driving the WebAssembly development for industrial and embedded usages. He is part of the group setting up the SIG-Embedded.

Optional: Endorsements
Xin Wang (@xwang98)

I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)