### PR TITLE
Add Nason, Benbuck as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -70,6 +70,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Mikushin, Ivan ([@imikushin](https://github.com/imikushin))
 * Mohan, Divya ([@divya-mohan0209](https://github.com/divya-mohan0209))
 * Narayan, Shravan ([@shravanrn](https://github.com/shravanrn))
+* Nason, Benbuck ([@bnason-nf](https://github.com/bnason-nf))  
 * Noorali, Michelle ([@michelleN](https://github.com/michelleN))
 * Parker, Sam ([@sparker-arm](https://github.com/sparker-arm))
 * Penzin, Petr ([@ppenzin](https://github.com/ppenzin))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Nason, Benbuck
GitHub Username: @bnason-nf

Nomination
Nason has been actively contributing to WebAssembly Micro Runtime project. His contribution list:  https://github.com/bytecodealliance/wasm-micro-runtime/commits?author=bnason-nf

Optional: Endorsements
Xin Wang (@xwang98)

I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)