### PR TITLE
Add Li Jiongqiang as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -58,6 +58,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Kolny, Marcin ([@loganek](https://github.com/loganek))
 * Kulakowski, George ([@kulakowski-wasm](https://github.com/kulakowski-wasm))
 * Levick, Ryan ([@rylev](https://github.com/rylev/))
+* Li Jiongqiang ([@FromLiQg])(https://github.com/FromLiQg)  
 * Liang Tianlong ([@TianlongLiang](https://github.com/TianlongLiang))
 * Litskevich, Maks ([@Zzzabiyaka](https://github.com/Zzzabiyaka))
 * Loparco, Enrico ([@eloparco](https://github.com/eloparco))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

Name: Li Jiongqiang
GitHub Username: @FromLiQg

Nomination
Jiongqiang has been actively contributing to WebAssembly Micro Runtime project. His contribution list: https://github.com/bytecodealliance/wasm-micro-runtime/commits?author=FromLiQg

Optional: Endorsements
Xin Wang (@xwang98)

I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)