### PR TITLE
docs(rc): nominate Lucas Fontes

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -32,6 +32,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Fallin, Chris ([@cfallin](https://github.com/cfallin))
 * Fitzgerald, Nick ([@fitzgen](https://github.com/fitzgen))
 * Foltzer, Adam ([@acfoltzer](https://github.com/acfoltzer))
+* Fontes, Lucas ([@lxfontes](https://github.com/lxfontes))
 * Freyler, Robin ([@robbepop](https://github.com/robbepop))
 * Galli, Enrico ([@egalli](https://github.com/egalli))
 * Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))


### PR DESCRIPTION
Signed-off-by: Bailey Hayes <behayes2@gmail.com>

I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Lucas Fontes
**GitHub Username:** lxfontes
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- SIG Guest Languages Go Subgroup
- [wasm-tools](https://github.com/bytecodealliance/wasm-tools/pulls?q=is%3Apr+author%3Alxfontes)
- [wasm-tools-go](https://github.com/bytecodealliance/wasm-tools-go/pulls?q=is%3Apr+author%3Alxfontes)
- [go-vanity-urls](https://github.com/bytecodealliance/go-vanity-urls/commits?author=lxfontes)

## Nomination
Lucas is part of the Golang Subgroup in SIG Guest Languages and has been working towards improving the golang guest producer toolchain. He maintains the vanity URL for our go projects, prototyped ergonomic go marshalling of CM types, and is actively working towards a `wasm-tools-go` only toolchain (instead of requiring shelling out to wasm-tools).

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)