### PR TITLE
docs(rc): nominate Mendy Berger

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -8,6 +8,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 
 * Bakker, Dave ([@badeend](https://github.com/badeend))
 * Bedford, Guy ([@guybedford](https://github.com/guybedford))
+* Berger, Mendy ([@MendyBerger](https://github.com/MendyBerger))
 * Birch Jr, Johnnie L ([@jlb6740](https://github.com/jlb6740))
 * bjorn3 ([@bjorn3](https://github.com/bjorn3))
 * Bofarull, Antoni ([@tonibofarull](https://github.com/tonibofarull))


### PR DESCRIPTION
I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Mendy Berger
**GitHub Username:** MendyBerger
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC
-->
- Contributor to wasm-tools including his addition of [wit-encoder](https://github.com/bytecodealliance/wasm-tools/pull/1580) and has continued to expand it's feature set like adding [serde support](https://github.com/bytecodealliance/wasm-tools/pull/1647).

## Nomination

Mendy is a regular collaborator in various WebAssembly contexts within and beyond the Bytecode Alliance. His contributions include work on [wasm-tools](https://github.com/search?q=repo%3Abytecodealliance%2Fwasm-tools+MendyBerger&type=pullrequests), [documentation on MDN](https://github.com/mdn/content/pull/32919), and championing the [wasi-gfx](https://github.com/WebAssembly/wasi-gfx/commits?author=MendyBerger) WASI proposal. His efforts to enhance wasi-gfx portability have significantly advanced bridging between WASI and web contexts.

Mendy facilitates a working meeting within the Bytecode Alliance focused on implementing wasi-gfx. Additionally, he has developed several valuable ecosystem tools, including [webidl2wit](https://github.com/wasi-gfx/webidl2wit) and [browser.wit](https://github.com/MendyBerger/browser.wit).

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Bailey Hayes (@ricochet)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)