### PR TITLE
Add @philipc as a recognized contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -26,6 +26,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Chegham, Wassim ([@manekinekko](https://github.com/manekinekko))
 * Chu, Karen ([@karenhchu](https://github.com/karenhchu))
 * Clark, Lin ([@linclark](https://github.com/linclark))
+* Craig, Philip ([@philipc](https://github.com/philipc))
 * Crichton, Alex ([@alexcrichton](https://github.com/alexcrichton))
 * Delendik, Yury ([@yurydelendik](https://github.com/yurydelendik))
 * Dice, Joel ([@dicej](https://github.com/dicej))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Philip Craig
**GitHub Username:** @philipc
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any. Note that an individual is not required to be affiliated with a project before becoming an RC
-->
- Wasmtime

## Nomination
Extensive work on Wasmtime's DWARF debugging support: https://github.com/bytecodealliance/wasmtime/commits?author=philipc

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status. -->
- @fitzgen

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)