### PR TITLE
Add @beetrees to recognized-contributors.md

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -48,6 +48,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Hickey, Pat ([@pchickey](https://github.com/pchickey))
 * Hillerström, Daniel ([@dhil](https://github.com/dhil))
 * Holley, Bobby ([@bholley](https://github.com/bholley))
+* Houldsworth, Bee ([@beetrees](https://github.com/beetrees))
 * Hoyer, Harald ([@haraldh](https://github.com/haraldh))
 * Huang Qi ([@no1wudi](https://github.com/no1wudi))
 * Huang Wenyong ([@wenyongh](https://github.com/wenyongh))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Bee Houldsworth
**GitHub Username:** @beetrees
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any. Note that an individual is not required to be affiliated with a project before becoming an RC -->
- Cranelift

## Nomination
Adding support for f16 and f128 to Cranelift, improving backend lowerings, and some other bug fixes: https://github.com/bytecodealliance/wasmtime/commits?author=beetrees

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status. -->
- @fitzgen

- [X] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)