### PR TITLE
Clarify approach to Hosted Projects

### DIFF
--- a/TSC/hosted-project-governance.md
+++ b/TSC/hosted-project-governance.md
@@ -1,0 +1,29 @@
+# Hosted Project Governance
+Published: March 10, 2025
+
+## Definition
+The Bytecode Alliance Technical Steering Committee (TSC) [charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) defines two types of Bytecode Alliance Projects -- "Hosted" and "Core", saying:
+> By default a project adopted by the BA is considered a Hosted Project. The BA board designates specific projects at Core Projects, requiring adherence to heightened standards around project governance, mission alignment, communication, and security. … Core Projects must meet all the requirements of Hosted Projects, but each project has exactly one status – Hosted or Core.
+
+Further, the TSC charter lists these requirements for Hosted Projects:
+* Alignment with BA mission and goals
+* Open governance
+* Correct licenses or ability to change license to correct one
+* Apache 2.0 or exception granted by the board
+* No processes that give any organization an elevated position
+* Stricter alignment and process requirements for Core than Hosted projects
+* Good software development (pull requests, issue maintenance) and security practices (reporting, responding to issues)
+* Including compliance with the BA’s security policies
+* Under active development or maintenance
+* BA ownership of name/trademark/social media channels, etc
+
+Additional details on Core and Hosted Project [requirements](https://github.com/bytecodealliance/governance/blob/main/TSC/core-and-hosted-projects.md) along with templates for proposing adoption are documented in the [TSC](https://github.com/bytecodealliance/governance/tree/main/TSC) portion of the Bytecode Alliance governance [repository](https://github.com/bytecodealliance/governance/tree/main).
+
+## In Practice
+The TSC, as the top-level governing body for Alliance projects and groups, oversees the adoption of projects as Hosted as well as reviewing Hosted Projects to evaluate whether they continue to meet the stated requirements. In practice, the TSC interprets those responsibilities as follows:
+1. Approval for adoption as a Hosted Project will be largely based on the TSC’s assessment as to whether the project aligns with the BA mission and goals, with an understanding of how Hosted Project status mutually benefits the project and the Alliance. The other stated requirements will be examined, but the TSC will exercise wide latitude in doing so. There is no intent to tightly constrain the number or nature of Hosted Projects or to make becoming a Hosted Project especially burdensome once it is clear the project is well aligned with the Alliance’s mission and goals.
+2. While the TSC has established a template for use in proposing any project for consideration as a Hosted Project, in an effort to save time and effort it has independently reviewed the current collection of projects operating within the Bytecode Alliance organization on GitHub, preapproving most as deserving Hosted Project status but also identifying a small number that have been archived.
+3. Designation as a Core Project is based on review and approval by the Bytecode Alliance board, informed by formal assessment from the TSC as to how the project satisfies suitably higher standards around project governance, mission alignment, communication, and security.  The process for proposing and reviewing Core Projects is well documented [elsewhere](https://github.com/bytecodealliance/governance/blob/main/TSC/core-and-hosted-projects.md) and has proven adequate to the Alliance’s current needs.
+
+The TSC actively maintains a [list of Alliance projects](https://github.com/bytecodealliance/governance/blob/main/projects/README.md), identifying them as Hosted or Core, along with useful general information about those projects. 
+

--- a/TSC/hosted-project-governance.md
+++ b/TSC/hosted-project-governance.md
@@ -3,13 +3,12 @@ Published: March 10, 2025
 
 ## Definition
 The Bytecode Alliance Technical Steering Committee (TSC) [charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) defines two types of Bytecode Alliance Projects -- "Hosted" and "Core", saying:
-> By default a project adopted by the BA is considered a Hosted Project. The BA board designates specific projects at Core Projects, requiring adherence to heightened standards around project governance, mission alignment, communication, and security. … Core Projects must meet all the requirements of Hosted Projects, but each project has exactly one status – Hosted or Core.
+> By default a project adopted by the BA is considered a Hosted Project. The BA board also designates specific projects as Core Projects, requiring adherence to heightened standards around project governance, mission alignment, communication, and security. Core Projects must meet all the requirements of Hosted Projects, but each project has exactly one status – Hosted or Core.
 
 Further, the TSC charter lists these requirements for Hosted Projects:
 * Alignment with BA mission and goals
 * Open governance
-* Correct licenses or ability to change license to correct one
-* Apache 2.0 or exception granted by the board
+* [Correct licenses](https://github.com/bytecodealliance/governance/blob/main/templates/projects/proposal-core-project.md#licensing-compatible-with-the-bytecode-alliance) or ability to change license to correct one
 * No processes that give any organization an elevated position
 * Stricter alignment and process requirements for Core than Hosted projects
 * Good software development (pull requests, issue maintenance) and security practices (reporting, responding to issues)


### PR DESCRIPTION
Per action item from March 4 TSC meeting, document TSC's approach to governance of Hosted Projects relative to existing processes and definitions (e.g., in the TSC Charter).