### PR TITLE
Add MangoPeachGrape as a Recognized Contributor

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -44,6 +44,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Garfinkel, Tal ([@talg](https://github.com/talg))
 * Gohman, Dan ([@sunfishcode](https://github.com/sunfishcode))
 * Goldenring, Kate ([@kate-goldenring](https://github.com/kate-goldenring))
+* Grape, MangoPeach ([@MangoPeachGrape](https://github.com/MangoPeachGrape))
 * Gregory, Eric ([ericgregory](https://github.com/ericgregory))
 * Hardock, Brian ([@fibonacci1729](https://github.com/fibonacci1729))
 * Hayes, Bailey ([@ricochet](https://github.com/ricochet))


### PR DESCRIPTION
I am nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** MangoPeachGrape
**GitHub Username:** @MangoPeachGrape
**Projects/SIGs:**
- Wasmtime

## Nomination

I'd like to nominate @MangoPeachGrape as a recognized contributor of the Bytecode Alliance. They have, and are currently executing on, an excellent series of contributions to the Wasmtime project to add Component Model support the the C API fo Wasmtime. This work has included implementing designs, creating designs, refactoring existing infrastructure, and generally being quite responsive. It's been a pleasure working with @MangoPeachGrape!

## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- Alex Crichton (@alexcrichton)

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors)

---

@MangoPeachGrape there's more info [here](https://github.com/technosophos/governance/blob/main/TSC/charter.md#recognized-contributors) on what this means, but tl;dr; no obligations on your end I just wanted to show appreciation! I've also filled in your GitHub username as the name here, but if you'd prefer I'd be happy to change that as well (and it's of course fine to leave as-is as well)