### PR TITLE
feat: add opentelemetry-wasi

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -30,6 +30,7 @@ This directory acts as an overview of the projects that the Alliance hosts.
  * [go-modules](https://github.com/bytecodealliance/go-modules)
  * [Javy](https://github.com/bytecodealliance/javy)
  * [jco](https://github.com/bytecodealliance/jco)
+ * [opentelemetry-wasi](https://github.com/bytecodealliance/opentelemetry-wasi)
  * [regalloc2](https://github.com/bytecodealliance/regalloc2)
  * [Warg](https://github.com/bytecodealliance/registry)
  * [rust-oci-wasm](https://github.com/bytecodealliance/rust-oci-wasm)

--- a/projects/hosted/opentelemetry-wasi.md
+++ b/projects/hosted/opentelemetry-wasi.md
@@ -1,0 +1,42 @@
+# Proposal to create opentelemetry-wasi
+This document is a proposal to create `opentelemetry-wasi` as a formal (Hosted) project under the auspices of the TSC of the Bytecode Alliance, as specified in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md).
+
+## Project Summary
+`opentelemetry-wasi` is a project to implement `wasi-otel` in languages with both WebAssembly and OpenTelemetry support. It currently resides at https://github.com/calebschoepp/opentelemetry-wasi/. We aim to make this set of WebAssembly guest language SDKs work seamlessly with the existing OpenTelemetry SDKs.
+
+## Governance Summary
+This project will begin with @asteurer (Andrew Steurer, Volunteer) and @calebschoepp (Caleb Schoepp, Akamai) as the primary maintainers. By making this a hosted Bytecode Alliance project, we hope to attract additional contributors going forward.
+
+## Software Development Process
+The project will meet the passing criteria for the [OpenSSF best practices badge](https://bestpractices.coreinfrastructure.org/en/criteria/0). Pull requests, issues, CI, and release management will be performed via GitHub.
+
+## Alignment with Bytecode Alliance Mission and Goals
+Bytecode Alliance projects represent the mission and goals of the Bytecode Alliance itself. We understand that as a Bytecode Alliance project, our project must adhere to the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) and other governing documents (such as the [Security Policies](https://bytecodealliance.org/security) and [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf)). As a Bytecode Alliance project, our project's source code and other pieces of intellectual property will be assigned to the Bytecode Alliance.
+
+We understand and agree that:
+
+* All code for this project must be under the [Apache v2 License with the LLVM exception](https://github.com/PROJECT_LICENSE), unless an exception is required for compliance with existing licensing, and granted by the Bytecode Alliance's board of directors per [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf) §4. If our code is not already licensed accordingly, we will take the necessary steps to correct this prior to becoming a Bytecode Alliance Project.
+
+* We will comply with the [Security Policies](https://bytecodealliance.org/security).
+
+* Project name, trademarks, logos, wordmarks, and other intellectual property other than source code and documentation copyright is assigned to Bytecode Alliance per the [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf).
+
+* Social media handles, GitHub repository access, and other relevant communication and coordination platforms will be overseen by Bytecode Alliance. Administrative/Owner permissions will be granted to the Bytecode Alliance for all such accounts.
+
+* We will abide by the definition of a project as set forth in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md).
+
+* This project must remain under active development or maintenance, or it may be archived by the Bytecode Alliance.
+
+* This project may be reviewed from time to time by the TSC, and project maintainers will assist with this review process.
+
+* Project members will be able to participate in Bytecode Alliance governance, as specified in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) and other governing documents.
+
+
+## Supporting Members
+The following individuals support the creation of opentelemetry-wasi
+
+* Andrew Steurer (@asteurer, Volunteer)
+
+* Caleb Schoepp (@calebschoepp, Akamai)
+
+* Bailey Hayes (@ricochet, Wasmcloud)

--- a/projects/hosted/opentelemetry-wasi.md
+++ b/projects/hosted/opentelemetry-wasi.md
@@ -43,7 +43,7 @@ Requirement is fulfilled by way of opentelemetry-wasi striving to implement the 
 >
 > Having a code of conduct is crucial for creating a positive and respectful environment in any organization, community, or group. It serves as a set of guidelines that outline expected behavior and ethical standards for all members involved.
 
-CODE_OF_CONDUCT.md file will be added before the repository is transferred.
+Already part of the repository: https://github.com/calebschoepp/opentelemetry-wasi/blob/main/CODE_OF_CONDUCT.md
 
 ### Continuous Integration Testing
 
@@ -63,7 +63,7 @@ The project currently has a CI pipeline complete with both unit and integration 
 >
 > A `CONTRIBUTING.md` serves as a guide for potential contributors, outlining the expectations for individuals who wish to contribute to the project. The Bytecode Alliance is a community-driven software foundation and documents like `CONTRIBUTING.md` are necessary for fostering community contributions.
 
-CONTRIBUTING.md file will be added to before the repository is transferred.
+Already part of the repository: https://github.com/calebschoepp/opentelemetry-wasi/blob/main/CODE_OF_CONDUCT.md
 
 ### Following the Bytecode Alliance Operational Principles
 
@@ -98,7 +98,7 @@ Both @asteurer and @calebschoepp will adhere to the Bytecode Alliance Operationa
 >
 > We strive to build an open community and a legally-compatible software ecosystem.
 
-Repository currently has an Apache-2.0 WITH LLVM-exception license (see [license](https://github.com/calebschoepp/opentelemetry-wasi/blob/main/LICENSE))
+Already part of the repository: https://github.com/calebschoepp/opentelemetry-wasi/blob/main/LICENSE
 
 ### README
 
@@ -110,7 +110,7 @@ Repository currently has an Apache-2.0 WITH LLVM-exception license (see [license
 >
 > The most important information about the project should be "above the fold". Projects should identify themselves as Bytecode Alliance projects so that, with time, people associate the Bytecode Alliance with quality projects that they can rely on.
 
-Repository will have an updated README.md file before it is transferred.
+Already part of the repository: https://github.com/calebschoepp/opentelemetry-wasi/blob/main/README.md
 
 ### Release Process
 
@@ -167,7 +167,7 @@ This repository will never hardcode secrets in source code.
 >
 > Our mission of developing runtime environments and language toolchains where security, efficiency, and modularity can all coexist necessarily means that we have performed our due dilligence to mitigate software supply chain attacks.
 
-At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, each SDK's repo will integrate the language-specific auditing tools to ensure supply chain security.
+Already part of the repository: https://github.com/calebschoepp/opentelemetry-wasi/blob/main/Justfile#L3
 
 ### Sustainable Contributor Base
 

--- a/projects/hosted/opentelemetry-wasi.md
+++ b/projects/hosted/opentelemetry-wasi.md
@@ -1,42 +1,297 @@
-# Proposal to create opentelemetry-wasi
-This document is a proposal to create `opentelemetry-wasi` as a formal (Hosted) project under the auspices of the TSC of the Bytecode Alliance, as specified in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md).
+# Proposal to Create opentelemetry-wasi
 
-## Project Summary
-`opentelemetry-wasi` is a project to implement `wasi-otel` in languages with both WebAssembly and OpenTelemetry support. It currently resides at https://github.com/calebschoepp/opentelemetry-wasi/. We aim to make this set of WebAssembly guest language SDKs work seamlessly with the existing OpenTelemetry SDKs.
+This document is a proposal to create opentelemetry-wasi as a formal Hosted Project under the auspices of the TSC of the Bytecode Alliance, as specified in the TSC’s charter.
 
-## Governance Summary
-This project will begin with @asteurer (Andrew Steurer, Volunteer) and @calebschoepp (Caleb Schoepp, Akamai) as the primary maintainers. By making this a hosted Bytecode Alliance project, we hope to attract additional contributors going forward.
+Proposing the adoption of opentelemetry-wasi as a Bytecode Alliance hosted project.
 
-## Software Development Process
-The project will meet the passing criteria for the [OpenSSF best practices badge](https://bestpractices.coreinfrastructure.org/en/criteria/0). Pull requests, issues, CI, and release management will be performed via GitHub.
+Current Repository URL: github.com/calebschoepp/opentelemetry-wasi
 
-## Alignment with Bytecode Alliance Mission and Goals
-Bytecode Alliance projects represent the mission and goals of the Bytecode Alliance itself. We understand that as a Bytecode Alliance project, our project must adhere to the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) and other governing documents (such as the [Security Policies](https://bytecodealliance.org/security) and [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf)). As a Bytecode Alliance project, our project's source code and other pieces of intellectual property will be assigned to the Bytecode Alliance.
+Proposed Repository URL: github.com/bytecodealliance/opentelemetry-wasi
 
-We understand and agree that:
+`opentelemetry-wasi` is a project to implement `wasi-otel` in all languages with both WebAssembly and OpenTelemetry support. We aim to make this set of WebAssembly guest language SDKs work seamlessly with the existing OpenTelemetry SDKs.
 
-* All code for this project must be under the [Apache v2 License with the LLVM exception](https://github.com/PROJECT_LICENSE), unless an exception is required for compliance with existing licensing, and granted by the Bytecode Alliance's board of directors per [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf) §4. If our code is not already licensed accordingly, we will take the necessary steps to correct this prior to becoming a Bytecode Alliance Project.
+## Requirements
 
-* We will comply with the [Security Policies](https://bytecodealliance.org/security).
+### Alignment with the Bytecode Alliance Mission
 
-* Project name, trademarks, logos, wordmarks, and other intellectual property other than source code and documentation copyright is assigned to Bytecode Alliance per the [IP Policy](https://bytecodealliance.org/assets/ip-policy.pdf).
+> Projects must have alignment with [the Bytecode Alliance mission:](https://github.com/bytecodealliance/governance/blob/main/mission.md)
+>
+> > Our mission is to provide state-of-the-art foundations to develop runtime environments and language toolchains where security, efficiency, and modularity can all coexist across a wide range of devices and architectures. We enable innovation in compilers, runtimes, and tooling, focusing on fine-grained sandboxing, capabilities-based security, modularity, and standards such as WebAssembly and WASI.
+>
+> The Bytecode Alliance is a group with a specific mission, and we therefore will only sponsor projects that are in alignment with and further that mission. For example, project sponsorship is untenable if the project undermines sandboxing, security, or standardization efforts.
 
-* Social media handles, GitHub repository access, and other relevant communication and coordination platforms will be overseen by Bytecode Alliance. Administrative/Owner permissions will be granted to the Bytecode Alliance for all such accounts.
+Requirement is fulfilled by way of opentelemetry-wasi striving to implement the wasi:otel interface for all WebAssembly and OpenTelemetry supported languages.
 
-* We will abide by the definition of a project as set forth in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md).
+### Code Review
 
-* This project must remain under active development or maintenance, or it may be archived by the Bytecode Alliance.
+#### Description
 
-* This project may be reviewed from time to time by the TSC, and project maintainers will assist with this review process.
+> All projects must gate merging pull requests on code reviews that audit not only for style but also substance, such as whether security invariants are properly maintained by the new code.
+>
+> It is recommended, but not required, that hosted projects maintain a `CODEOWNERS` file and automatically assign reviewers as well.
+>
+> Code reviews have a demonstrable impact on the quality of source code by catching bugs early, determining the best possible implementation, and fostering trust within the community. Timely responses let contributors know that their work is valued and encourages further contribution.
 
-* Project members will be able to participate in Bytecode Alliance governance, as specified in the [TSC Charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md) and other governing documents.
+@asteurer and @calebschoepp will be the code owners and are both active open source maintainers and contributors.
 
+### Code of Conduct
 
-## Supporting Members
-The following individuals support the creation of opentelemetry-wasi
+> All Bytecode Alliance projects must:
+>
+> * link to the Bytecode Alliance's Code of Conduct documents from a `CODE_OF_CONDUCT.md` file in root of the repository, and
+> * enforce the codes of conduct among the community and contributors, or escalate to [the Bytecode Alliance CoC Team](mailto:report@bytecodealliance.org), if needed.
+>
+> Having a code of conduct is crucial for creating a positive and respectful environment in any organization, community, or group. It serves as a set of guidelines that outline expected behavior and ethical standards for all members involved.
 
-* Andrew Steurer (@asteurer, Volunteer)
+CODE_OF_CONDUCT.md file will be added before the repository is transferred.
 
-* Caleb Schoepp (@calebschoepp, Akamai)
+### Continuous Integration Testing
 
-* Bailey Hayes (@ricochet, Wasmcloud)
+> All projects must run continuous integration (CI) tests on all pull requests and merges. Key project features must be covered by CI.
+>
+> If any part of the CI gates on merging changes that is not reproducible by external contributors, then the project must make affordances to support those external contributors.
+>
+> Implementing CI offers several benefits to software projects, helping ensure correctness and quality, making it an essential practice for modern software development.
+
+The project currently has a CI pipeline complete with both unit and integration tests (see [integration_tests](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/integration_tests))
+
+### Contributor Documentation
+
+> All projects must have a `CONTRIBUTING.md` document in the root of their repository. This document must provide, or link to another form of project-specific documentation that provides, high-quality contributor documentation.
+>
+> See ["How to build a `CONTRIBUTING.md`" by the Mozilla Science Lab](https://mozillascience.github.io/working-open-workshop/contributing/) for more details on what a high-quality `CONTRIBUTING.md` file looks like.
+>
+> A `CONTRIBUTING.md` serves as a guide for potential contributors, outlining the expectations for individuals who wish to contribute to the project. The Bytecode Alliance is a community-driven software foundation and documents like `CONTRIBUTING.md` are necessary for fostering community contributions.
+
+CONTRIBUTING.md file will be added to before the repository is transferred.
+
+### Following the Bytecode Alliance Operational Principles
+
+> All projects must follow [the Bytecode Alliance Operational Principles](https://github.com/bytecodealliance/governance/blob/main/operational-principles.md).
+>
+> In pursuing our mission and vision, the Bytecode Alliance follows a set of operational principles aimed at keeping us aligned on three key aspects: what we want to create, how we want to work together, and how we want to work with others.
+
+Both @asteurer and @calebschoepp will adhere to the Bytecode Alliance Operational Principles.
+
+### Licensing Compatible with the Bytecode Alliance
+
+> All projects must be licensed under the Apache 2.0 license with an LLVM exception. Exemptions may be granted by the board.
+>
+> All projects must only use dependencies and third-party code licensed under one of the following open source licenses:
+>
+> * Apache-2.0 WITH LLVM-exception
+> * Apache-2.0
+> * BSD-2-Clause
+> * BSD-3-Clause
+> * ISC
+> * MIT
+> * MPL-2.0
+> * OpenSSL
+> * Unicode-DFS-2016
+> * Zlib
+>
+> All dependencies and third-party code must be properly attributed.
+>
+> The source for all projects must be available to all members and must be available to all non-members under the same license.
+>
+> All projects must automatically ensure that licensing requirements of dependencies are met in CI.
+>
+> We strive to build an open community and a legally-compatible software ecosystem.
+
+Repository currently has an Apache-2.0 WITH LLVM-exception license (see [license](https://github.com/calebschoepp/opentelemetry-wasi/blob/main/LICENSE))
+
+### README
+
+> All hosted projects must have a `README.md` file in the root of the repository which begins with:
+>
+> * The project name and logo (if one exists)
+> * A one-sentence description of the project
+> * `<strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> hosted project</strong>`
+>
+> The most important information about the project should be "above the fold". Projects should identify themselves as Bytecode Alliance projects so that, with time, people associate the Bytecode Alliance with quality projects that they can rely on.
+
+Repository will have an updated README.md file before it is transferred.
+
+### Release Process
+
+> Documentation of a release process that any project maintainer may execute to create a new release version of the software.
+>
+> Multiple people must have permissions to publish releases. A github team must have access to publish packages and package ownership on the associated package repository when possible. For example a Rust project may have multiple owners on crates.io.
+>
+> Projects and their releases shouldn't be tied to any single user's machine or keys to ensure continuity of the project. A project isn't an open, community project if only one person can publish releases.
+>
+> Automation makes fewer mistakes than humans, and getting releases right is critical, since only releases are typically used downstream, not random commits from `main`.
+
+At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, the repository will have a well-documented release process that will be accessible to any and all project maintainers.
+
+### Security Process
+
+> All projects must have a documented security process for reporting and disclosing vulnerabilities, managing patches that fix vulnerabilities, and announcing and making available security releases. Furthermore, projects must actually follow their documented processes.
+>
+> It is recommended that request Common Vulnerability and Exposure (CVE) numbers for discovered vulnerabilities and report the CVE when disclosing the vulnerability.
+>
+> A tool like [dependabot](https://github.com/dependabot) may suffice for hosted projects. Dependabot should be used for security updates only, and not apply all updates indiscriminantly. Updating dependencies should otherwise be done with intention (never automatically). Automatic creation of pull requests is acceptable, but manual review is required to prevent supply chain attacks.
+>
+> Bytecode Alliance projects must be a secure foundation for others to build upon. Transparency and a managed security release process is key to being this foundation.
+
+At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, the repository will have a well-documented security process.
+
+### Semantic Versioning
+
+> All projects must follow either standard semantic versioning or their ecosystem's local-dialect of semantic versioning (for example, Rust and `cargo`'s interpretation of semantic versioning slightly differs from the standard, but is acceptable for Rust Bytecode Alliance projects).
+>
+> A clear versioning scheme is necessary for end-users. We desire consistency across projects and so the Bytecode Alliance has adopted semantic versioning as a required best practice.
+
+At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, each SDK's repo will mirror its' corresponding opentelemetry SDK's semantic version.
+
+### Secrets Management
+
+> GitHub organization and repository level secrets should be used. Secrets must not be hard coded in source.
+>
+> For secrets like passwords for the project's associated social media account, these should be stored in the password service paid for by the Bytecode Alliance. Contact the TSC for access and ability to manage a given secret.
+>
+> Secure secret management is a requirement for a secure project. Additionally, projects and their associated accounts shouldn't be tied to any single user's machine or keys to ensure continuity of the project. A project isn't an open, community project if only one person can access its accounts.
+
+This repository will never hardcode secrets in source code.
+
+### Supply Chain Security
+
+> All projects must follow a well-documented process for updating dependencies and auditing them for malicious supply-chain attacks.
+>
+> When applicable, projects should:
+>
+> * Integrate auditing tools in CI (such as `cargo vet`)
+> * Use code review and static analysis tools on dependencies
+>
+> Finally, projects must document and follow their process for responding to upstream vulnerabilities in dependencies.
+>
+> Our mission of developing runtime environments and language toolchains where security, efficiency, and modularity can all coexist necessarily means that we have performed our due dilligence to mitigate software supply chain attacks.
+
+At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, each SDK's repo will integrate the language-specific auditing tools to ensure supply chain security.
+
+### Sustainable Contributor Base
+
+> All projects must have regular contributions from multiple contributors.
+>
+> It is recommended that hosted projects additionally have contributors affiliated with at least two different Bytecode Alliance organizations and that the project's leadership has representation from at least two different Bytecode Alliance organizations.
+>
+> There must not be any private information necessary to fully contribute to the project.
+>
+> A project is not considered healthy with only one contributor. An open, community project requires input from multiple stakeholders and does not rely on a single person.
+>
+> The TSC may waive the above contributor base requirements under certain conditions. In particular, the TSC may decide to adopt crucial upstream dependencies of existing Bytecode Alliance projects that are otherwise effectively unmaintained or only have a single maintainer.
+
+This project has two regular contributors, and there is no private information necessary to contribute to the project.
+
+### Version Control
+
+> All projects must be hosted on [the Bytecode Alliance Organization](github.com/bytecodealliance) on GitHub.
+>
+> Access controls are managed via the Bytecode Alliance organization on GitHub. This allows for continuity of the project when hosted in one place. Finally, this is the only way to reasonable manage the projects within the organization.
+
+This project is currently being hosted on github at https://github.com/calebschoepp/openetelemetry-wasi
+
+## Recommendations
+
+### Changelog
+
+> It is recommended that hosted projects highlight key additions, breaking changes, security fixes, and otherwise noteworthy changes in a changelog.
+>
+> See [keepachangelog.com](https://keepachangelog.com/en/1.1.0/) for a recommended approach.
+>
+> We are building an ecosystem that developers can depend on, and one small part of that is communicating important changes downstream.
+
+At some point in the near future, this repository will be broken up into language-specific repos. When this occurs, each SDK's repo will have a changelog for each release.
+
+### Continuous Fuzzing
+
+> Not all projects will necessarily benefit from fuzzing, for example benchmark suites. The TSC may choose lift this requirement for a particular project.
+>
+> It is recommended that hosted projects have 24/7, round the clock, continuous fuzzing. The fuzzing should exercise significant amounts of the code base and test the project's most important properties, such as sandboxing. Bugs and vulnerabilities discovered via fuzzing should be addressed promptly.
+>
+> Part of our open-source and open contribution model, the corpus and setup for running fuzzing should be open-sourced as part of the project.
+>
+> Faults discovered via fuzzing must be reported privately to the project's core team so that the project's security vulnerability process can be followed properly, if necessary. For example, fuzzing infrastructure must not automatically open public issues for any fault that is discovered.
+>
+> Continuous fuzzing is a valuable practice for projects, due to its significant benefits in improving security and reliability. Within the Bytecode Alliance, we host projects that provide a sandbox. The fidelity of these sandboxes must be battle-tested via a number of methodologies including automated fuzzing.
+
+Fuzzing is not likely to be necessary for this project.
+
+### End-User Documentation
+
+> We abide by [the OpenSSF requirements for documentation](https://bestpractices.coreinfrastructure.org/en):
+>
+> > The documentation of an external interface explains to an end-user or developer how to use it. This would include its application program interface (API) if the software has one. If it is a library, document the major classes/types and methods/functions that can be called. If it is a web application, define its URL interface (often its REST interface). If it is a command-line interface, document the parameters and options it supports. In many cases it's best if most of this documentation is automatically generated, so that this documentation stays synchronized with the software as it changes, but this isn't required. The project MAY use hypertext links to non-project material as documentation. Documentation MAY be automatically generated (where practical this is often the best way to do so).
+>
+> Furthermore, we identify a few different types of (sometimes overlapping) documentation:
+>
+> * **API documentation**: Documentation for each type, method, function, and module in a library.
+> * **Architectural overviews**: High-level documentation about the architecture of the project and how it works from a 1000-foot view that helps endusers take advantage of the project in the best way possible and helps onboard new contributors.
+> * **Examples**: Code examples that show off how to use the project as a whole or particular features it supports.
+> * **Guides and tutorials**: Long-form prose, with code samples interspersed, that shows how to accomplish a task using the project.
+>
+> API and CLI flag documentation is required for hosted projects; all other types are recommended.
+>
+> Documentation is necessary for end-users to productively use the project; source code comments are not sufficient.
+
+Each language SDK has in-depth examples and documentation (see the [Rust](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/rust/examples), [Go](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/golang/examples), and [TypeScript](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/ts/examples) examples).
+
+### Issue Triage Process
+
+> Hosted projects must use an issue tracker for tracking individual issues.
+>
+> It is recommended that hosted projects should additionally have a documented process for expeditiously triaging incoming issues and pull requests, and follow that process. Contributors should get prompt responses to their issues and pull requests, even if a response is not an immediate fix or review.
+>
+> For a successful community-driven project, expedient communication within issues and PRs encourages further collaboration and contribution.
+
+This project already has an active issue tracker (see [issues](https://github.com/calebschoepp/opentelemetry-wasi/issues))
+
+### Leverage the Bytecode Alliance RFC Process
+
+> A request for comments (RFC) is a technique for soliciting the community and contributors for feedback on proposed major changes and decisions.
+>
+> It is recommended that hosted projects follow [the Bytecode Alliance RFC process](https://github.com/bytecodealliance/rfcs/blob/main/accepted/rfc-process.md) for changes that significantly affect project stakeholders or contributors. The RFCs repo describes [when an RFC is needed](https://github.com/bytecodealliance/rfcs/#when-is-an-rfc-needed) in more detail:
+>
+> > Many changes to Bytecode Alliance projects can and should happen through every-day GitHub processes: issues and pull requests. An RFC is warranted when:
+> >
+> > * The work involves changes that will significantly affect stakeholders or project contributors. Each project may provide more specific guidance. Examples include:
+> >     * Major architectural changes
+> >     * Major new features
+> >     * Simple changes that have significant downstream impact
+> >     * Changes that could affect guarantees or level of support, e.g. removing support for a target platform
+> >     * Changes that could affect mission alignment, e.g. by changing properties of the security model
+> > * The work is substantial and you want to get early feedback on your approach.
+>
+> This is a best practice for aligning contributors, the community, and downstream projects' needs with proposed technical implementations.
+
+This project will be in lock-step with the existing opentelemetry SDKs for each supported language, so an RFC process is unlikely to be necessary.
+
+### Production Use
+
+> It is recommended that hosted projects have demonstrated use in production by at least three independent organizations which are, in the TSC's judgement, of adequate quality and scope.
+>
+> It is recommended that projects track production usage by organizations in an `ADOPTERS.md` at the root of the project, for example see [`ADOPTERS.md`](https://github.com/bytecodealliance/wasmtime/blob/main/ADOPTERS.md) in Wasmtime.
+>
+> Projects should demonstrate that they are practical, useful, and reliable enough to use in production.
+
+So far, opentelemetry-wasi is being used in production by spinframework/spin and wasmcloud/wasmcloud.
+
+### Public Project Meetings and Notes
+
+> It is recommended that hosted projects hold regular and public project meetings. Meeting times and frequency should be advertised publicly, for example in the project's `CONTRIBUTING.md`. To avoid spam and "Zoom bombing", the video conferencing link need not be public, but should be available upon request.
+>
+> Agendas for upcoming meetings and notes from past meetings should be published publicly. The notes should be in the `bytecodealliance/meetings` repository.
+>
+> Public meetings encourage open communication, collaboration, and engagement within the project's community. Notes allow community members who were not present to remain aligned and can document any decisions made during the meeting.
+
+With two active contributors, our meetings tend to be ad-hoc; however, if the volume of contributors gets to the point where we need regular meetings, we will document meeting times and frequencies in the CONTRIBUTING.md file.
+
+### Sanitizers and Code Analysis
+
+> Static and dynamic code analysis tools (such as `valgrind` or `miri`) where applicable are recommended to be used by hosted projects.
+>
+> It is recommended that hosted projects with non-trivial amounts of unsafe code (e.g. `unsafe` in Rust or any C/C++)  run tests and fuzzers with the relevant sanitizers: Address Sanitizer, Memory Sanitizer, Thread Sanitizer, etc.
+>
+> Automated code analysis is key to meeting our mission of developing runtime environments and language toolchains where security, efficiency, and modularity can all coexist.
+
+Code analysis tools are not currently necessary for this project.


### PR DESCRIPTION
`opentelemetry-wasi` is a project to implement `wasi-otel` in languages with both WebAssembly and OpenTelemetry support. It currently resides at https://github.com/calebschoepp/opentelemetry-wasi/. We aim to make this set of WebAssembly guest language SDKs work seamlessly with the existing OpenTelemetry SDKs.

@calebschoepp @ricochet