### PR TITLE
Add Caleb Schoepp as RC

### DIFF
--- a/recognized-contributors.md
+++ b/recognized-contributors.md
@@ -98,6 +98,7 @@ Format of entries: `Surname, First name (GitHub Username)`. When it is tradition
 * Rodrigues, Eduardo ([@eduardomourar](https://github.com/eduardomourar))
 * Ruppel, Emily ([@kangaruppel](https://github.com/kangaruppel))
 * Schneidereit, Till ([@tschneidereit](https://github.com/tschneidereit))
+* Schoepp, Caleb ([@calebschoepp](https://github.com/calebschoepp))
 * Schoettler, Steve ([@stevelr](https://github.com/stevelr))
 * Sharp, Jamey ([@jameysharp](https://github.com/jameysharp))
 * Silesmo, Timmy ([@silesmo](https://github.com/silesmo))


### PR DESCRIPTION
I am nominating or self-nominating a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors).

**Name:** Caleb Schoepp
**GitHub Username:** @calebschoepp
**Projects/SIGs:**
<!-- 
List projects or SIGs this person is affiliated with, if any.
Note that an individual is not required to be affiliated
with a project before becoming an RC.
-->
- opentelemetry-wasi
- 
## Nomination
<!-- In 2-5 sentences, describe this person's activity within the Bytecode Alliance. Examples include SIG activity, project contributions, and supporting Bytecode Alliance-wide initiatives.
-->

Caleb is a co-maintainer of opentelemetry-wasi, which is about to be transferred to the Bytecode Alliance in #151. He's also a co-champion of the underlying wasi-otel proposal and has a long history of engagement an contributions in the WebAssembly ecosystem.


## Optional: Endorsements
<!--
List endorsments in the form Name (GitHub Username) of existing RCs who endorse this person's candidacy for RC status.
-->
- @tschneidereit 

- [x] I have read and understood the qualifications for a [Recognized Contributor](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors)